### PR TITLE
[DAEMON-103] appcd start waits for daemon to boot.

### DIFF
--- a/docs/Appcd/Commands/restart.md
+++ b/docs/Appcd/Commands/restart.md
@@ -37,5 +37,4 @@ Simply press <kbd>CTRL-C</kbd> to quit the Appc Daemon
 | 0     | Success                    |
 | 1     | An error occurred          |
 | 2     | Showed help screen         |
-| 4     | Server is already running  |
 | 5     | Server was run as root     |

--- a/packages/appcd-agent/package.json
+++ b/packages/appcd-agent/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-client/package.json
+++ b/packages/appcd-client/package.json
@@ -18,12 +18,12 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
     "appcd-response": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "msgpack-lite": "^0.1.26",
     "source-map-support": "^0.5.0",
     "uuid": "^3.1.0",

--- a/packages/appcd-config-service/package.json
+++ b/packages/appcd-config-service/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-config/package.json
+++ b/packages/appcd-config/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-core/package.json
+++ b/packages/appcd-core/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
@@ -30,7 +30,7 @@
     "appcd-response": "0.1.0",
     "appcd-subprocess": "0.1.0",
     "appcd-telemetry": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "cli-kit": "^0.0.3",
     "fs-extra": "^4.0.2",
     "gawk": "^4.3.0",

--- a/packages/appcd-core/src/main.js
+++ b/packages/appcd-core/src/main.js
@@ -27,7 +27,12 @@ new CLI({
 	.then(({ argv }) => {
 		return import('./server')
 			.then(server => new server.default(argv))
-			.then(server => server.start());
+			.then(server => server.start())
+			.then(() => {
+				if (process.connected) {
+					process.send('booted');
+				}
+			});
 	})
 	.catch(err => {
 		console.error(err);

--- a/packages/appcd-core/src/server.js
+++ b/packages/appcd-core/src/server.js
@@ -3,7 +3,6 @@ import ConfigService from 'appcd-config-service';
 import Dispatcher from 'appcd-dispatcher';
 import fs from 'fs-extra';
 import FSWatchManager from 'appcd-fswatcher';
-import gawk from 'gawk';
 import os from 'os';
 import path from 'path';
 import PluginManager from 'appcd-plugin';

--- a/packages/appcd-core/yarn.lock
+++ b/packages/appcd-core/yarn.lock
@@ -198,8 +198,8 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -248,12 +248,12 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
 dateformat@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
 
 debug@^2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -960,8 +960,8 @@ mkdirp@^0.5.0:
     minimist "0.0.8"
 
 moment@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1265,8 +1265,8 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 supports-color@^4.0.0, supports-color@^4.2.1:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
 

--- a/packages/appcd-detect/package.json
+++ b/packages/appcd-detect/package.json
@@ -12,14 +12,14 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
     "appcd-dispatcher": "0.1.0",
     "appcd-logger": "0.1.0",
     "appcd-path": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "gawk": "^4.3.0",
     "source-map-support": "^0.5.0"
   },

--- a/packages/appcd-dispatcher/package.json
+++ b/packages/appcd-dispatcher/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-dispatcher/yarn.lock
+++ b/packages/appcd-dispatcher/yarn.lock
@@ -812,9 +812,9 @@ path-root@^0.1.1:
   dependencies:
     path-root-regex "^0.1.0"
 
-path-to-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.0.0.tgz#b77a8168c2e78bc31f3d312d71b1ace97df23870"
+path-to-regexp@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.1.0.tgz#7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b"
 
 preserve@^0.2.0:
   version "0.2.0"

--- a/packages/appcd-fs/package.json
+++ b/packages/appcd-fs/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-fswatcher/package.json
+++ b/packages/appcd-fswatcher/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
@@ -20,7 +20,7 @@
     "appcd-logger": "0.1.0",
     "appcd-path": "0.1.0",
     "appcd-response": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "gawk": "^4.3.0",
     "source-map-support": "^0.5.0"
   },

--- a/packages/appcd-gulp/yarn.lock
+++ b/packages/appcd-gulp/yarn.lock
@@ -1303,9 +1303,9 @@ esdoc@^1.0.3:
     minimist "1.2.0"
     taffydb "2.7.2"
 
-eslint-config-axway@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-config-axway/-/eslint-config-axway-2.0.3.tgz#5db08d589dafa949d015f7819a02a60dc2538ecb"
+eslint-config-axway@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/eslint-config-axway/-/eslint-config-axway-2.0.4.tgz#ece9826a4d517992fdf6cae29217cd5d7da446bc"
   dependencies:
     eslint-plugin-import "^2.7.0"
     eslint-plugin-security "^1.4.0"

--- a/packages/appcd-http/package.json
+++ b/packages/appcd-http/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-http/yarn.lock
+++ b/packages/appcd-http/yarn.lock
@@ -1224,9 +1224,9 @@ path-root@^0.1.1:
   dependencies:
     path-root-regex "^0.1.0"
 
-path-to-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.0.0.tgz#b77a8168c2e78bc31f3d312d71b1ace97df23870"
+path-to-regexp@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.1.0.tgz#7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b"
 
 platform@1.3.4:
   version "1.3.4"

--- a/packages/appcd-logger/package.json
+++ b/packages/appcd-logger/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-machine-id/package.json
+++ b/packages/appcd-machine-id/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
@@ -20,7 +20,7 @@
     "appcd-logger": "0.1.0",
     "appcd-path": "0.1.0",
     "appcd-subprocess": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "appcd-winreg": "0.1.0",
     "fs-extra": "^4.0.2",
     "macaddress": "^0.2.8",

--- a/packages/appcd-nodejs/package.json
+++ b/packages/appcd-nodejs/package.json
@@ -12,14 +12,14 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
     "appcd-fs": "0.1.0",
     "appcd-logger": "0.1.0",
     "appcd-request": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "fs-extra": "^4.0.2",
     "progress": "^2.0.0",
     "source-map-support": "^0.5.0",

--- a/packages/appcd-path/package.json
+++ b/packages/appcd-path/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-plugin/package.json
+++ b/packages/appcd-plugin/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
@@ -26,7 +26,7 @@
     "appcd-path": "0.1.0",
     "appcd-response": "0.1.0",
     "appcd-subprocess": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "builtin-modules": "^1.1.1",
     "gawk": "^4.3.0",
     "globule": "^1.2.0",

--- a/packages/appcd-plugin/yarn.lock
+++ b/packages/appcd-plugin/yarn.lock
@@ -601,8 +601,8 @@ invariant@^2.2.2:
     loose-envify "^1.0.0"
 
 irregular-plurals@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.3.0.tgz#7af06931bdf74be33dcf585a13e06fccc16caecf"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
 
 is-absolute@^0.2.3:
   version "0.2.6"

--- a/packages/appcd-request/package.json
+++ b/packages/appcd-request/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-response/package.json
+++ b/packages/appcd-response/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-subprocess/package.json
+++ b/packages/appcd-subprocess/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-telemetry/package.json
+++ b/packages/appcd-telemetry/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
@@ -24,7 +24,7 @@
     "appcd-path": "0.1.0",
     "appcd-request": "0.1.0",
     "appcd-response": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "fs-extra": "^4.0.2",
     "source-map-support": "^0.5.0",
     "uuid": "^3.1.0"

--- a/packages/appcd-telemetry/yarn.lock
+++ b/packages/appcd-telemetry/yarn.lock
@@ -247,12 +247,6 @@ fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-gawk@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/gawk/-/gawk-4.3.0.tgz#a826a9bcd9e4e33c9379c03fc16afe9ba4140fb3"
-  dependencies:
-    source-map-support "^0.4.16"
-
 gaze@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/gaze/-/gaze-0.5.2.tgz#40b709537d24d1d45767db5a908689dfe69ac44f"
@@ -946,21 +940,11 @@ sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
-source-map-support@^0.4.16:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  dependencies:
-    source-map "^0.5.6"
-
 source-map-support@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
   dependencies:
     source-map "^0.6.0"
-
-source-map@^0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
 source-map@^0.6.0:
   version "0.6.1"

--- a/packages/appcd-util/package.json
+++ b/packages/appcd-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-util",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Various utility functions to support the Appc Daemon.",
   "main": "./dist/util",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd-winreg/package.json
+++ b/packages/appcd-winreg/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/packages/appcd/package.json
+++ b/packages/appcd/package.json
@@ -20,7 +20,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
@@ -31,7 +31,7 @@
     "appcd-logger": "0.1.0",
     "appcd-nodejs": "0.1.0",
     "appcd-path": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "cli-kit": "^0.0.3",
     "cli-table2": "^0.2.0",
     "source-map-support": "^0.5.0"

--- a/packages/appcd/src/common.js
+++ b/packages/appcd/src/common.js
@@ -106,6 +106,7 @@ export function startServer({ cfg, argv }) {
 	const { config, configFile, debug } = argv;
 	const args = [];
 	const detached = debug ? false : cfg.get('server.daemonize');
+	const stdio = detached ? [ 'ignore', 'ignore', 'ignore', 'ipc' ] : 'inherit';
 	const v8mem = cfg.get('core.v8.memory');
 	const corePkgJson = JSON.parse(fs.readFileSync(require.resolve('appcd-core/package.json'), 'utf8'));
 
@@ -126,37 +127,49 @@ export function startServer({ cfg, argv }) {
 
 	process.env.APPCD_BOOTSTRAP = appcdVersion;
 
-	// check if we should use the core's required Node.js version
-	if (cfg.get('core.enforceNodeVersion') !== false) {
-		if (!nodeVer) {
-			throw new Error(`Invalid Node.js engine version from appcd-core package.json: ${nodeVer}`);
-		}
+	return Promise.resolve()
+		.then(() => {
+			// check if we should use the core's required Node.js version
+			if (cfg.get('core.enforceNodeVersion') !== false) {
+				if (!nodeVer) {
+					throw new Error(`Invalid Node.js engine version from appcd-core package.json: ${nodeVer}`);
+				}
 
-		return spawnNode({
-			args,
-			detached,
-			nodeHome: expandPath(cfg.get('home'), 'node'),
-			version:  nodeVer,
-			v8mem
-		});
-	}
+				return spawnNode({
+					args,
+					nodeHome: expandPath(cfg.get('home'), 'node'),
+					stdio,
+					v8mem,
+					version:  nodeVer
+				});
+			}
 
-	// using the current Node.js version which may be incompatible with the core
+			// using the current Node.js version which may be incompatible with the core
 
-	if (v8mem) {
-		const arg = generateV8MemoryArgument(v8mem);
-		if (arg) {
-			args.unshift(arg);
-		}
-	}
+			if (v8mem) {
+				const arg = generateV8MemoryArgument(v8mem);
+				if (arg) {
+					args.unshift(arg);
+				}
+			}
 
-	const opts = {};
-	if (detached) {
-		opts.detached = true;
-		opts.stdio = 'ignore';
-	}
+			return spawn(process.execPath, args, { stdio });
+		})
+		.then(child => new Promise((resolve, reject) => {
+			if (detached) {
+				child.on('message', msg => {
+					if (msg === 'booted') {
+						child.disconnect();
+						child.unref();
+						resolve();
+					}
+				});
 
-	return spawn(process.execPath, args, opts);
+				child.on('close', code => {
+					reject(code);
+				});
+			}
+		}));
 }
 
 /**

--- a/packages/appcd/src/restart.js
+++ b/packages/appcd/src/restart.js
@@ -1,4 +1,4 @@
-import { loadConfig, startServer, stopServer } from './common';
+import { banner, loadConfig, startServer, stopServer } from './common';
 
 const cmd = {
 	options: {
@@ -7,8 +7,24 @@ const cmd = {
 	async action({ argv }) {
 		const cfg = loadConfig(argv);
 
-		await stopServer({ cfg });
-		await startServer({ cfg, argv });
+		console.log(banner());
+
+		const wasRunning = await stopServer({ cfg, force: true });
+
+		try {
+			await startServer({ cfg, argv });
+			console.log(wasRunning ? 'Appc Daemon restarted' : 'Appc Daemon started');
+		} catch (code) {
+			switch (code) {
+				case 1:
+					console.error('Failed to restart the Appc Daemon');
+					break;
+
+				case 5:
+					console.error('Error: Daemon cannot be run as root');
+					break;
+			}
+		}
 	}
 };
 

--- a/packages/appcd/src/start.js
+++ b/packages/appcd/src/start.js
@@ -1,4 +1,4 @@
-import { loadConfig, startServer } from './common';
+import { banner, loadConfig, startServer } from './common';
 
 const cmd = {
 	options: {
@@ -7,7 +7,26 @@ const cmd = {
 	async action({ argv }) {
 		const cfg = loadConfig(argv);
 
-		await startServer({ cfg, argv });
+		console.log(banner());
+
+		try {
+			await startServer({ cfg, argv });
+			console.log('Appc Daemon started');
+		} catch (code) {
+			switch (code) {
+				case 1:
+					console.error('Failed to start the Appc Daemon');
+					break;
+
+				case 4:
+					console.log('Appc Daemon already started');
+					break;
+
+				case 5:
+					console.error('Error: Daemon cannot be run as root');
+					break;
+			}
+		}
 	}
 };
 

--- a/packages/appcd/src/stop.js
+++ b/packages/appcd/src/stop.js
@@ -1,10 +1,12 @@
-import { loadConfig, stopServer } from './common';
+import { banner, loadConfig, stopServer } from './common';
 
 const cmd = {
 	options: {
 		'--force': { desc: 'force the daemon to stop' }
 	},
 	async action({ argv }) {
+		console.log(banner());
+
 		const wasRunning = await stopServer({
 			cfg: loadConfig(argv),
 			force: argv.force

--- a/packages/appcd/yarn.lock
+++ b/packages/appcd/yarn.lock
@@ -191,8 +191,8 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -934,8 +934,8 @@ mkdirp@^0.5.0:
     minimist "0.0.8"
 
 moment@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1248,8 +1248,8 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 supports-color@^4.0.0, supports-color@^4.2.1:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
 

--- a/plugins/appcd-plugin-jdk/package.json
+++ b/plugins/appcd-plugin-jdk/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/plugins/appcd-plugin-jdk/yarn.lock
+++ b/plugins/appcd-plugin-jdk/yarn.lock
@@ -3,8 +3,8 @@
 
 
 ajv@^5.1.0:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.4.tgz#3daf9a8b67221299fdae8d82d117ed8e6c80244b"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -239,8 +239,8 @@ chalk@^1.0.0, chalk@^1.1.1:
     supports-color "^2.0.0"
 
 chalk@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -870,9 +870,9 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-jdklib@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/jdklib/-/jdklib-2.0.4.tgz#22f7f0160e9db643f1dc00e7efc2ec4d3a4e3d95"
+jdklib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jdklib/-/jdklib-2.1.0.tgz#45190bb4911889c97c1848690c2ab1abc2135970"
   dependencies:
     appcd-fs "^0.1.0"
     appcd-logger "^0.1.0"
@@ -1114,8 +1114,8 @@ mkdirp@^0.5.0:
     minimist "0.0.8"
 
 moment@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 
 multipipe@^0.1.2:
   version "0.1.2"
@@ -1237,8 +1237,8 @@ path-root@^0.1.1:
     path-root-regex "^0.1.0"
 
 path-to-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.0.0.tgz#b77a8168c2e78bc31f3d312d71b1ace97df23870"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.1.0.tgz#7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b"
 
 pause-stream@0.0.11:
   version "0.0.11"
@@ -1523,8 +1523,8 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 supports-color@^4.0.0, supports-color@^4.2.1:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
 

--- a/plugins/appcd-plugin-system-info/package.json
+++ b/plugins/appcd-plugin-system-info/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build",
     "coverage": "gulp coverage",
     "docs": "gulp docs",
-    "prepublish": "gulp build",
+    "prepare": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {
@@ -21,7 +21,7 @@
     "appcd-path": "0.1.0",
     "appcd-response": "0.1.0",
     "appcd-subprocess": "0.1.0",
-    "appcd-util": "0.1.0",
+    "appcd-util": "0.1.1",
     "gawk": "^4.3.0",
     "source-map-support": "^0.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1760,9 +1760,9 @@ iferr@^0.1.5, iferr@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
-ignore@^3.3.5:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"
+ignore@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.6.tgz#b6f3196b38ed92f0c86e52f6f79b7fc4c8266c8d"
 
 imurmurhash@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
[DAEMON-103] appcd start waits for daemon to boot.

Changed bootstrap to spawn the core attached (not detached), then it disconnects after the core process is booted.

Cleaned up appcd start, stop, restart ux.

Updated all package.json files to use 'prepare' instead of 'prepublish' to make npm 5 happy.

Added 'stdio' option to appcd-nodejs spawnNode().

Updated npm deps.