### PR TITLE
Use Node 8.8.1 on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ timestamps {
       currentBuild.displayName = "#${packageVersion}-${currentBuild.number}"
     }
 
-    nodejs(nodeJSInstallationName: 'node 8.7.0') {
+    nodejs(nodeJSInstallationName: 'node 8.8.1') {
       ansiColor('xterm') {
         stage('Install') {
           timeout(15) {


### PR DESCRIPTION
Jenkins has been blowing up recently due to Node 8.7.0 not being installed https://jenkins.appcelerator.org/job/cli/job/appc-daemon/job/master/68/console

hyperloop.next repo now uses 8.8.1 so lets use that https://github.com/appcelerator/hyperloop.next/pull/179#issuecomment-340483478