### PR TITLE
[DAEMON-115] appcd: config command should maybe return object when --json

### DIFF
--- a/packages/appcd/src/config.js
+++ b/packages/appcd/src/config.js
@@ -164,7 +164,7 @@ export default cmd;
  */
 function printAndExit(key, value, json, exitCode = 0, code = '0') {
 	if (json) {
-		if (value && typeof value === 'object') {
+		if (value && typeof value === 'object' && !Array.isArray(value)) {
 			if (!value.code) {
 				value.code = code;
 			}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/DAEMON-115

Example responses 
```
$appcd config get x --json
{
  "code": "0",
  "message": "a",
  "success": "true"
}
```

```
$appcd config pop a  --json
{
  "success": true,
  "message": "foo",
  "code": "0"
}
```