### PR TITLE
Updated to latest snooplogg which fixes console.trace().

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,7 +146,7 @@ gulp.task('stats', () => {
 
 gulp.task('upgrade', cb => {
 	Promise.resolve()
-		.then(() => checkPackages())
+		.then(() => checkPackages({ skipSecurity: true }))
 		.then(results => upgradeDeps(results.packagesToUpdate))
 		.then(() => checkPackages({ skipSecurity: true }))
 		.then(results => renderPackages(results))
@@ -882,6 +882,9 @@ async function checkPackages({ skipSecurity } = {}) {
 										const dep = obj.component;
 										const version = obj.version;
 										issue.retire = true;
+										if (!dependencies[dep].versions[version]) {
+											dependencies[dep].versions[version] = [];
+										}
 										dependencies[dep].versions[version].push(issue);
 									}
 								}

--- a/packages/appcd-logger/package.json
+++ b/packages/appcd-logger/package.json
@@ -16,7 +16,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "snooplogg": "^1.8.1",
+    "snooplogg": "^1.9.0",
     "source-map-support": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/appcd-plugin/src/plugin-base.js
+++ b/packages/appcd-plugin/src/plugin-base.js
@@ -42,20 +42,7 @@ export default class PluginBase extends EventEmitter {
 		 * The plugin's namespaced logger.
 		 * @type {SnoopLogg}
 		 */
-		const { log } = this.logger = appcdLogger(plugin.toString());
-		Object.defineProperty(this.logger, 'trace', {
-			value: (...args) => {
-				const err = {
-					name: 'Trace',
-					message: util.format.apply(null, args),
-					toString() {
-						return this.name + (this.message ? `: ${this.message}` : '');
-					}
-				};
-				Error.captureStackTrace(err);
-				log(err.stack);
-			}
-		});
+		this.logger = appcdLogger(plugin.toString());
 
 		/**
 		 * The Appc Daemon config.

--- a/packages/appcd-plugin/src/tunnel.js
+++ b/packages/appcd-plugin/src/tunnel.js
@@ -81,7 +81,7 @@ export default class Tunnel {
 					message
 				};
 
-				this.logger.log('Sending tunnel response to %s:', highlight(this.remoteName), response);
+				// this.logger.log('Sending tunnel response to %s:', highlight(this.remoteName), response);
 				this.proc.send(response);
 			});
 		};

--- a/plugins/appcd-plugin-ios/package.json
+++ b/plugins/appcd-plugin-ios/package.json
@@ -20,7 +20,7 @@
     "appcd-dispatcher": "^1.0.0-5",
     "appcd-util": "^1.0.0-5",
     "gawk": "^4.4.4",
-    "ioslib": "^2.0.0-4",
+    "ioslib": "^2.0.0-6",
     "source-map-support": "^0.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6385,9 +6385,9 @@ snooplogg@^1.8.0:
     source-map-support "^0.4.16"
     supports-color "^4.2.1"
 
-snooplogg@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/snooplogg/-/snooplogg-1.8.1.tgz#611ed2fe9aa7ce92c42c1219acd802b47f5df5b5"
+snooplogg@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/snooplogg/-/snooplogg-1.9.0.tgz#9baf4e8af9e4cb6dcaaf343ba6524f4cb3a034ce"
   dependencies:
     brotli "^1.3.2"
     chalk "^2.3.0"


### PR DESCRIPTION
Updated to latest snooplogg which fixes console.trace().

Bypassed security checks when doing an upgrade.

Added better logging to the iOS plugin.

[DAEMON-143] Fixed timing issue with the iOS plugin returning the results after getting the Xcodes, but before getting the simulators. https://jira.appcelerator.org/browse/DAEMON-143