### PR TITLE
Bug fixes and several changes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1164,15 +1164,15 @@ function renderPackages(results) {
 	const cyclicDepCount = cyclicPkgs.length;
 	if (cyclicDepCount) {
 		for (const name of cyclicPkgs.sort()) {
-			console.log(name);
+			console.log(` ${name}`);
 			for (const deps of results.cyclic[name]) {
-				console.log('  > ' + deps.map((s, i, a) => i + 1 === a.length ? red(s) : s).join(' > '));
+				console.log('   > ' + deps.map((s, i, a) => i + 1 === a.length ? red(s) : s).join(' > '));
 			}
 			console.log();
 		}
-		console.log(red(`Found ${cyclicDepCount} package${cyclicDepCount === 1 ? '' : 's'} with cyclic dependencies!`));
+		console.log(red(` Found ${cyclicDepCount} package${cyclicDepCount === 1 ? '' : 's'} with cyclic dependencies!`));
 	} else {
-		console.log('No cyclic dependencies found');
+		console.log(' No cyclic dependencies found');
 	}
 	console.log();
 

--- a/packages/appcd-detect/src/detector.js
+++ b/packages/appcd-detect/src/detector.js
@@ -60,7 +60,7 @@ export default class Detector extends EventEmitter {
 
 			if (results[dir]) {
 				log('      Already found a result for this path');
-				return true;
+				return;
 			}
 
 			const result = await opts.checkDir(dir);
@@ -80,7 +80,8 @@ export default class Detector extends EventEmitter {
 			log('    Walking subdirectories');
 			for (const name of fs.readdirSync(dir)) {
 				const subdir = real(path.join(dir, name));
-				if (await checkDir(subdir, depth - 1) || (Object.keys(results).length && !opts.multiple)) {
+				await checkDir(subdir, depth - 1);
+				if (Object.keys(results).length && !opts.multiple) {
 					return;
 				}
 			}

--- a/packages/appcd-plugin/src/plugin.js
+++ b/packages/appcd-plugin/src/plugin.js
@@ -117,6 +117,7 @@ export default class Plugin extends EventEmitter {
 			if (typeof pkgJson.name !== 'string') {
 				throw new PluginError('Invalid "name" property in %s', pkgJsonFile);
 			}
+			this.packageName = pkgJson.name;
 			this.name = slug(pkgJson.name);
 		}
 
@@ -154,6 +155,9 @@ export default class Plugin extends EventEmitter {
 			if (appcdPlugin.name) {
 				if (typeof appcdPlugin.name !== 'string') {
 					throw new PluginError('Invalid "name" property in the "appcd-plugin" section of %s', pkgJsonFile);
+				}
+				if (!this.packageName) {
+					this.packageName = appcdPlugin.name;
 				}
 				this.name = slug(appcdPlugin.name);
 			}

--- a/plugins/appcd-plugin-android/src/android-info-service.js
+++ b/plugins/appcd-plugin-android/src/android-info-service.js
@@ -287,7 +287,7 @@ export default class AndroidInfoService extends DataServiceDispatcher {
 			delete this.subscriptions[type][sid];
 		}
 
-		if (!Object.keys(this.subscriptions[type])) {
+		if (!Object.keys(this.subscriptions[type]).length) {
 			delete this.subscriptions[type];
 		}
 	}

--- a/plugins/appcd-plugin-genymotion/src/genymotion-info-service.js
+++ b/plugins/appcd-plugin-genymotion/src/genymotion-info-service.js
@@ -260,7 +260,7 @@ export default class GenymotionInfoService extends DataServiceDispatcher {
 			delete this.subscriptions[type][sid];
 		}
 
-		if (!Object.keys(this.subscriptions[type])) {
+		if (!Object.keys(this.subscriptions[type]).length) {
 			delete this.subscriptions[type];
 		}
 	}

--- a/plugins/appcd-plugin-ios/package.json
+++ b/plugins/appcd-plugin-ios/package.json
@@ -20,7 +20,8 @@
     "appcd-dispatcher": "^1.0.0-10",
     "appcd-util": "^1.0.0-10",
     "gawk": "^4.4.4",
-    "ioslib": "^2.0.0-8",
+    "ioslib": "^2.0.0-11",
+    "semver": "^5.4.1",
     "source-map-support": "^0.5.0"
   },
   "devDependencies": {

--- a/plugins/appcd-plugin-ios/src/version.js
+++ b/plugins/appcd-plugin-ios/src/version.js
@@ -1,0 +1,77 @@
+import semver from 'semver';
+
+function format(ver, min, max, chopDash) {
+	ver = ('' + (ver || 0));
+	if (chopDash) {
+		ver = ver.replace(/(-.*)?$/, '');
+	}
+	ver = ver.split('.');
+	if (min !== undefined) {
+		while (ver.length < min) {
+			ver.push('0');
+		}
+	}
+	if (max !== undefined) {
+		ver = ver.slice(0, max);
+	}
+	return ver.join('.');
+}
+
+function eq(v1, v2) {
+	return semver.eq(format(v1, 3, 3), format(v2, 3, 3));
+}
+
+function gte(v1, v2) {
+	return semver.gte(format(v1, 3, 3), format(v2, 3, 3));
+}
+
+function gt(v1, v2) {
+	return semver.gt(format(v1, 3, 3), format(v2, 3, 3));
+}
+
+function lte(v1, v2) {
+	return semver.lte(format(v1, 3, 3), format(v2, 3, 3));
+}
+
+function lt(v1, v2) {
+	return semver.lt(format(v1, 3, 3), format(v2, 3, 3));
+}
+
+function compare(v1, v2) {
+	return eq(v1, v2) ? 0 : lt(v1, v2) ? -1 : 1;
+}
+
+function rcompare(v1, v2) {
+	return eq(v1, v2) ? 0 : lt(v1, v2) ? 1 : -1;
+}
+
+function satisfies(ver, str) {
+	ver = format(ver, 3, 3, true);
+	str = str.replace(/(<=?\d+(\.\d+)*?)\.x/g, '$1.99999999').replace(/(>=?\d+(\.\d+)*?)\.x/g, '$1.0');
+	try {
+		if (str === '*' || eq(ver, str)) {
+			return true;
+		}
+	} catch (ex) {
+		// squelch
+	}
+
+	return str.split(/\s*\|\|\s*/).some(function (range) {
+		// semver is picky with the '-' in comparisons and it just so happens when it
+		// parses versions in the range, it will add '-0' and cause '1.0.0' != '1.0.0-0',
+		// so we test our version with and without the '-9'
+		return range === '*' || semver.satisfies(ver, range) || (ver.indexOf('-') === -1 && semver.satisfies(ver + '-0', range));
+	});
+}
+
+export default {
+	format,
+	eq,
+	gte,
+	gt,
+	lte,
+	lt,
+	compare,
+	rcompare,
+	satisfies
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,7 +3634,7 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ioslib@^2.0.0-8:
+ioslib@^2.0.0-11:
   version "2.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/ioslib/-/ioslib-2.0.0-beta.3.tgz#18ea323935eb5b08d2b77325a383ac05582d5f96"
   dependencies:


### PR DESCRIPTION
Cleaned up display output from gulp check.

Fixed bug in detect engine where subdirectories would stop scanning after visiting an already discovered item.

Added the ablity to stop a plugin by name or name and version in addition to specifying the full plugin path.

Added reject support to appcd-util's debounce().

Updated the iOS plugin to the new ioslib. Improved init sequence. Sprinkled several debouncers everywhere to limit rescans after a bit of activity.

Fixed bug in info service unwatch() functions where subscriptions were never being cleaned up.