### PR TITLE
[DAEMON-162] Move windowslib dependecy to appcd-core

### DIFF
--- a/packages/appcd-core/package.json
+++ b/packages/appcd-core/package.json
@@ -35,7 +35,8 @@
     "cli-kit": "^0.0.7",
     "fs-extra": "^4.0.2",
     "gawk": "^4.4.4",
-    "msgpack-lite": "^0.1.26"
+    "msgpack-lite": "^0.1.26",
+    "windowslib": "^0.6.0"
   },
   "devDependencies": {
     "appcd-gulp": "^1.0.0-10",

--- a/plugins/appcd-plugin-windows/README.md
+++ b/plugins/appcd-plugin-windows/README.md
@@ -1,14 +1,17 @@
-# appcd-plugin-jdk
+# appcd-plugin-windows
 
-JDK service for the Appc Daemon.
+Windows service for the Appc Daemon.
 
 ## Info
 
-The `info` service uses [jdklib](https://github.com/appcelerator/jdklib) to detect the installed
-JDKs and returns the information.
+The `info` service uses [windowslib](https://github.com/appcelerator/windowslib) to detect the installed
+Windows information and returns the information.
 
 ```js
-appcd.call('/jdk/latest/info', ctx => {
+appcd.call('/windows/latest/info', ctx => {
 	console.log(ctx.response);
 });
 ```
+
+
+You're probably wondering where the windowslib dependency is. It's in appcd-core due to the max path issues explained in [DAEMON-162](https://jira.appcelerator.org/browse/DAEMON-162), which will be fixed in [DAEMON-165](https://jira.appcelerator.org/browse/DAEMON-165)

--- a/plugins/appcd-plugin-windows/package.json
+++ b/plugins/appcd-plugin-windows/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "appcd-dispatcher": "^1.0.0-10",
     "gawk": "^4.4.4",
-    "source-map-support": "^0.5.0",
-    "windowslib": "^0.6.0"
+    "source-map-support": "^0.5.0"
   },
   "devDependencies": {
     "appcd-gulp": "^1.0.0-10",


### PR DESCRIPTION
This is a nasty, nasty hack.

https://jira.appcelerator.org/browse/DAEMON-165 deals with fixing it properly