### PR TITLE
[DAEMON-177] Scan emulators if we have no Android SDK results

### DIFF
--- a/plugins/appcd-plugin-android/src/android-info-service.js
+++ b/plugins/appcd-plugin-android/src/android-info-service.js
@@ -198,7 +198,7 @@ export default class AndroidInfoService extends DataServiceDispatcher {
 		});
 
 		return new Promise((resolve, reject) => {
-			// if xcodes change, then refresh the simulators
+			// if sdks change, then refresh the simulators
 			gawk.watch(this.data.sdk, async () => {
 				console.log('AndroidSDK changed, rescanning emulators');
 				gawk.set(this.data.emulators, await androidlib.emulators.getEmulators({ force: true, sdks: this.data.sdk }));
@@ -210,9 +210,10 @@ export default class AndroidInfoService extends DataServiceDispatcher {
 			});
 
 			this.sdkDetectEngine.start()
-				.then(results => {
+				.then(async results => {
 					if (!initialized && results.length === 0) {
 						initialized = true;
+						gawk.set(this.data.emulators, await androidlib.emulators.getEmulators({ force: true, sdks: this.data.sdk }));
 						resolve();
 					}
 				})

--- a/plugins/appcd-plugin-genymotion/package.json
+++ b/plugins/appcd-plugin-genymotion/package.json
@@ -17,7 +17,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "androidlib": "^2.0.0",
+    "androidlib": "^2.0.2",
     "appcd-detect": "^1.0.0-13",
     "appcd-dispatcher": "^1.0.0-13",
     "appcd-fs": "^1.0.0-13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,21 +166,6 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-androidlib@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/androidlib/-/androidlib-2.0.0.tgz#070350ab4983e448e94f41544fd329937917be81"
-  dependencies:
-    appcd-fs "^1.0.0-10"
-    appcd-logger "^1.0.0-10"
-    appcd-path "^1.0.0-10"
-    appcd-subprocess "^1.0.0-10"
-    appcd-util "^1.0.0-10"
-    appcd-winreg "^1.0.0-10"
-    cli-kit "^0.0.7"
-    fs-extra "^4.0.2"
-    simple-plist "^0.2.1"
-    source-map-support "^0.5.0"
-
 androidlib@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/androidlib/-/androidlib-2.0.2.tgz#50f1973ac1bcdcf79093f8fa2b80e8f7d1460f90"


### PR DESCRIPTION
https://jira.appcelerator.org/browse/DAEMON-177

If we have no SDKs we should trigger an emulator scan before resolving