### PR TITLE
[DAEMON-173] Wire up devices to workaround multiple wptool builds issue

### DIFF
--- a/packages/appcd-core/package.json
+++ b/packages/appcd-core/package.json
@@ -35,8 +35,7 @@
     "cli-kit": "^0.0.7",
     "fs-extra": "^4.0.2",
     "gawk": "^4.4.4",
-    "msgpack-lite": "^0.1.26",
-    "windowslib": "^0.6.0"
+    "msgpack-lite": "^0.1.26"
   },
   "devDependencies": {
     "appcd-gulp": "^1.0.0-13",

--- a/plugins/appcd-plugin-windows/package.json
+++ b/plugins/appcd-plugin-windows/package.json
@@ -19,7 +19,8 @@
     "appcd-dispatcher": "^1.0.0-13",
     "appcd-util": "^1.0.0-13",
     "gawk": "^4.4.4",
-    "source-map-support": "^0.5.0"
+    "source-map-support": "^0.5.0",
+    "windowslib": "^0.6.0"
   },
   "devDependencies": {
     "appcd-gulp": "^1.0.0-13",

--- a/plugins/appcd-plugin-windows/src/windows-info-service.js
+++ b/plugins/appcd-plugin-windows/src/windows-info-service.js
@@ -32,11 +32,14 @@ export default class WindowsInfoService extends DataServiceDispatcher {
 		await this.wireupDetection('visual-studio',    get(cfg, 'visualstudio.pollInterval') || 60000 * 10, () => this.detectVisualStudios());
 
 		await Promise.all([
-			this.wireupDetection('devices',            get(cfg, 'device.pollInterval')       || 2500,       () => this.detectDevices()),
 			this.wireupDetection('emulators',          get(cfg, 'emulators.pollInterval')    || 60000 * 5,  () => this.detectEmulators()),
 			this.wireupDetection('windows-sdks',       get(cfg, 'windows.pollInterval')      || 60000 / 2,  () => this.detectWindowsSDKs()),
 			this.wireupDetection('windows-phone-sdks', get(cfg, 'windowsphone.pollInterval') || 60000 / 2,  () => this.detectWindowsPhone())
 		]);
+
+		// wire up devices after the rest to avoid DAEMON-173 where emulator and
+		// device detect functions attempt to build and write wptool at the same time
+		await this.wireupDetection('devices',          get(cfg, 'device.pollInterval')       || 2500,       () => this.detectDevices());
 	}
 
 	/**


### PR DESCRIPTION
https://jira.appcelerator.org/browse/DAEMON-173

Move windowslib back under the windows plugin also

Merge after  https://github.com/appcelerator/windowslib/pull/80 is merged and published 