### PR TITLE
Use APPC_NPM_VERSION to check if ran through appc cli

### DIFF
--- a/packages/appcd/src/common.js
+++ b/packages/appcd/src/common.js
@@ -33,7 +33,7 @@ export function getAppcdVersion() {
  * @returns {String}
  */
 export function banner() {
-	if (process.env.hasOwnProperty('APPC_ENV')) {
+	if (process.env.hasOwnProperty('APPC_NPM_VERSION')) {
 		return '';
 	}
 


### PR DESCRIPTION
APPC_ENV seems to go walkies from time to time for me, APPC_NPM_VERSION seems to be more concrete as it is definitely set here https://github.com/appcelerator/appc-install/blob/master/bin/appc#L44