### PR TITLE
[DAEMON-185] Use correct path for request pid

### DIFF
--- a/packages/appcd/src/common.js
+++ b/packages/appcd/src/common.js
@@ -229,7 +229,7 @@ export function stopServer({ cfg, force }) {
 
 			log('Attempting to connect to the daemon and get the pid');
 
-			createRequest(cfg, '/appcd/pid')
+			createRequest(cfg, '/appcd/status/pid')
 				.request
 				.on('response', resolve)
 				.once('close', resolve)


### PR DESCRIPTION
https://jira.appcelerator.org/browse/DAEMON-185

/appcd/pid isn't found, I believe /appcd/status/pid is correct