### PR TITLE
Moved 'build' task to 'build-src' so that appcd-gulp consumers can ov…

### DIFF
--- a/packages/appcd-gulp/package.json
+++ b/packages/appcd-gulp/package.json
@@ -30,7 +30,7 @@
     "esdoc": "^1.0.4",
     "esdoc-ecmascript-proposal-plugin": "^1.0.0",
     "esdoc-standard-plugin": "^1.0.0",
-    "eslint": "^4.12.0",
+    "eslint": "^4.12.1",
     "eslint-config-axway": "^2.0.7",
     "eslint-plugin-mocha": "^4.11.0",
     "gulp-babel": "^7.0.0",

--- a/packages/appcd-gulp/src/templates/standard.js
+++ b/packages/appcd-gulp/src/templates/standard.js
@@ -59,7 +59,7 @@ module.exports = (opts) => {
 	/*
 	 * Clean tasks
 	 */
-	gulp.task('clean', ['clean-coverage', 'clean-dist', 'clean-docs']);
+	gulp.task('clean', [ 'clean-coverage', 'clean-dist', 'clean-docs' ]);
 
 	gulp.task('clean-coverage', done => { del(coverageDir, { force: true }).then(() => done()) });
 
@@ -106,7 +106,9 @@ module.exports = (opts) => {
 	/*
 	 * build tasks
 	 */
-	gulp.task('build', ['clean-dist', 'lint-src'], () => {
+	gulp.task('build', [ 'build-src' ]);
+
+	gulp.task('build-src', [ 'clean-dist', 'lint-src' ], () => {
 		return gulp.src('src/**/*.js')
 			.pipe($.plumber())
 			.pipe($.debug({ title: 'build' }))
@@ -119,7 +121,7 @@ module.exports = (opts) => {
 			.pipe(gulp.dest(distDir));
 	})
 
-	gulp.task('docs', ['lint-src', 'clean-docs'], () => {
+	gulp.task('docs', [ 'lint-src', 'clean-docs' ], () => {
 		const esdoc = require('esdoc').default;
 
 		esdoc.generate({
@@ -151,10 +153,10 @@ module.exports = (opts) => {
 	/*
 	 * test tasks
 	 */
-	gulp.task('test', ['build', 'lint-test'], () => runTests());
-	gulp.task('test-only', ['lint-test'], () => runTests());
-	gulp.task('coverage', ['clean-coverage', 'lint-src', 'lint-test'], () => runTests(true));
-	gulp.task('coverage-only', ['clean-coverage', 'lint-test'], () => runTests(true));
+	gulp.task('test',          [ 'build', 'lint-test' ],                      () => runTests());
+	gulp.task('test-only',     [ 'lint-test' ],                               () => runTests());
+	gulp.task('coverage',      [ 'clean-coverage', 'lint-src', 'lint-test' ], () => runTests(true));
+	gulp.task('coverage-only', [ 'clean-coverage', 'lint-test' ],             () => runTests(true));
 
 	function runTests(cover) {
 		const args = [];
@@ -266,5 +268,5 @@ module.exports = (opts) => {
 		}
 	}
 
-	gulp.task('default', ['build']);
+	gulp.task('default', [ 'build' ]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,9 +2330,9 @@ eslint@^4.0.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-eslint@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.12.0.tgz#a7ce78eba8cc8f2443acfbbc870cc31a65135884"
+eslint@^4.12.1:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.12.1.tgz#5ec1973822b4a066b353770c3c6d69a2a188e880"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"


### PR DESCRIPTION
Moved 'build' task to 'build-src' so that appcd-gulp consumers can override 'build' task if needed.