### PR TITLE
Fixed typo that caused a problem when the detect engine started scann…

### DIFF
--- a/packages/appcd-detect/src/detector.js
+++ b/packages/appcd-detect/src/detector.js
@@ -52,7 +52,7 @@ export default class Detector extends EventEmitter {
 		const foundPaths = new Set();
 
 		const checkDir = async (dir, depth) => {
-			if (!isDir(this.dir)) {
+			if (!isDir(dir)) {
 				return;
 			}
 


### PR DESCRIPTION
Fixed typo that caused a problem when the detect engine started scanning subdirectories.