### PR TITLE
[DAEMON-222] Allow plugins to register paths to be ignored

### DIFF
--- a/packages/appcd-fswatcher/src/fswatcher.js
+++ b/packages/appcd-fswatcher/src/fswatcher.js
@@ -393,6 +393,8 @@ export class Node {
 				&& evt.action === 'change'
 				&& stat.isDirectory()
 			) {
+				// This will drop also events where there is a permission change on the folder,
+				// tracked as https://jira.appcelerator.org/browse/DAEMON-232 - EH 02/08/18
 				log('Dropping Windows event for change on a directory when there is a change to a file');
 				return;
 			}

--- a/packages/appcd-fswatcher/src/fswatcher.js
+++ b/packages/appcd-fswatcher/src/fswatcher.js
@@ -387,6 +387,16 @@ export class Node {
 
 		try {
 			const stat = fs.lstatSync(evt.file);
+
+			if (process.platform === 'win32'
+				&& event === 'change'
+				&& evt.action === 'change'
+				&& stat.isDirectory()
+			) {
+				log('Dropping Windows event for change on a directory when there is a change to a file');
+				return;
+			}
+
 			isFile = stat.isFile();
 			this.files.set(filename, [ evt.action, now ]);
 		} catch (e) {

--- a/packages/appcd-plugin/src/external-plugin.js
+++ b/packages/appcd-plugin/src/external-plugin.js
@@ -407,8 +407,23 @@ export default class ExternalPlugin extends PluginBase {
 							if (this.watchers[dir]) {
 								this.appcdLogger.log('Already watching plugin directory %s', highlight(dir));
 							} else {
+								let prevEvt;
 								this.watchers[dir] = new FSWatcher(dir)
-									.on('change', onFilesystemChange);
+									.on('change', (evt) => {
+										if (prevEvt) {
+											if (process.platform === 'win32'
+												&& evt.file === this.plugin.path
+												&& path.dirname(prevEvt.file) === this.plugin.path
+												&& prevEvt.action === 'add'
+											) {
+												prevEvt = evt;
+												return;
+											}
+										} else {
+											prevEvt = evt;
+										}
+										return onFilesystemChange(evt);
+									});
 							}
 						}
 					}

--- a/packages/appcd-plugin/src/external-plugin.js
+++ b/packages/appcd-plugin/src/external-plugin.js
@@ -407,23 +407,8 @@ export default class ExternalPlugin extends PluginBase {
 							if (this.watchers[dir]) {
 								this.appcdLogger.log('Already watching plugin directory %s', highlight(dir));
 							} else {
-								let prevEvt;
 								this.watchers[dir] = new FSWatcher(dir)
-									.on('change', (evt) => {
-										if (prevEvt) {
-											if (process.platform === 'win32'
-												&& evt.file === this.plugin.path
-												&& path.dirname(prevEvt.file) === this.plugin.path
-												&& prevEvt.action === 'add'
-											) {
-												prevEvt = evt;
-												return;
-											}
-										} else {
-											prevEvt = evt;
-										}
-										return onFilesystemChange(evt);
-									});
+									.on('change', onFilesystemChange);
 							}
 						}
 					}

--- a/packages/appcd-plugin/src/external-plugin.js
+++ b/packages/appcd-plugin/src/external-plugin.js
@@ -368,17 +368,19 @@ export default class ExternalPlugin extends PluginBase {
 			args.unshift(`--inspect-brk=${debugPort}`);
 		}
 
-		const onFilesystemChange = debounce(() => {
-			this.appcdLogger.log('Detected change in plugin source file, stopping external plugin: %s', highlight(this.plugin.toString()));
-			this.stop()
-				.then(() => {
-					// reset the plugin error state
-					this.appcdLogger.log('Reseting error state');
-					this.info.error = null;
-				})
-				.catch(err => {
-					this.appcdLogger.error('Failed to restart %s plugin: %s', highlight(this.plugin.toString()), err);
-				});
+		const onFilesystemChange = debounce((e) => {
+			if (!this.plugin.ignore.includes(e.filename)) {
+				this.appcdLogger.log('Detected change in plugin source file, stopping external plugin: %s', highlight(this.plugin.toString()));
+				this.stop()
+					.then(() => {
+						// reset the plugin error state
+						this.appcdLogger.log('Reseting error state');
+						this.info.error = null;
+					})
+					.catch(err => {
+						this.appcdLogger.error('Failed to restart %s plugin: %s', highlight(this.plugin.toString()), err);
+					});
+			}
 		}, 2000);
 
 		return Promise.resolve()

--- a/packages/appcd-plugin/src/plugin.js
+++ b/packages/appcd-plugin/src/plugin.js
@@ -222,7 +222,7 @@ export default class Plugin extends EventEmitter {
 			if (!Array.isArray(appcd.ignore)) {
 				throw new PluginError('Expected ignore to be an array');
 			}
-			this.ignore.concat(appcd.ignore);
+			this.ignore = this.ignore.concat(appcd.ignore);
 		}
 
 		// validate the name

--- a/packages/appcd-plugin/src/plugin.js
+++ b/packages/appcd-plugin/src/plugin.js
@@ -217,6 +217,14 @@ export default class Plugin extends EventEmitter {
 			this.inactivityTimeout = appcd.inactivityTimeout;
 		}
 
+		this.ignore = [ '.git' ];
+		if (appcd.ignore) {
+			if (!Array.isArray(appcd.ignore)) {
+				throw new PluginError('Expected ignore to be an array');
+			}
+			this.ignore.concat(appcd.ignore);
+		}
+
 		// validate the name
 		if (!this.name) {
 			throw new PluginError('Invalid "name" property in the "appcd" section of %s', pkgJsonFile);

--- a/packages/appcd-plugin/test/fixtures/good-with-ignore/index.js
+++ b/packages/appcd-plugin/test/fixtures/good-with-ignore/index.js
@@ -1,0 +1,15 @@
+console.log('good external plugin required');
+let counter = 0;
+module.exports = {
+	activate() {
+
+		appcd.register('/counter', ctx => {
+			counter++;
+			ctx.response = counter;
+		});
+	},
+
+	deactivate() {
+		console.log('hi from deactivate!');
+	}
+};

--- a/packages/appcd-plugin/test/fixtures/good-with-ignore/package.json
+++ b/packages/appcd-plugin/test/fixtures/good-with-ignore/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "good plugin with ignore",
+	"version": "1.2.3",
+	"appcd-plugin": {
+		"name": "good-with-ignore",
+		"inactivityTimeout": 30000,
+		"ignore": [
+			"ignoredFile.txt"
+		]
+	}
+}

--- a/packages/appcd-plugin/test/test-plugin-manager.js
+++ b/packages/appcd-plugin/test/test-plugin-manager.js
@@ -470,11 +470,6 @@ describe('PluginManager', () => {
 
 			pm = new PluginManager();
 
-			pm
-				.on('reload', () => {
-					log('FFFFFFFFFFFFFFFFF');
-				});
-
 			setTimeout(() => {
 				pm
 					.call('/register', {

--- a/packages/appcd-plugin/test/test-plugin-manager.js
+++ b/packages/appcd-plugin/test/test-plugin-manager.js
@@ -459,6 +459,80 @@ describe('PluginManager', () => {
 			}, 1000);
 		});
 
+		it('should not reload a plugin when file is ignored', function (done) {
+			this.timeout(20000);
+			this.slow(19000);
+
+			const sourceDir = path.join(__dirname, 'fixtures', 'good-with-ignore');
+			const pluginDir = makeTempDir();
+
+			fs.copySync(sourceDir, pluginDir);
+
+			pm = new PluginManager();
+
+			pm
+				.on('reload', () => {
+					log('FFFFFFFFFFFFFFFFF');
+				});
+
+			setTimeout(() => {
+				pm
+					.call('/register', {
+						data: {
+							path: pluginDir
+						}
+					})
+					.then(() => {
+						log('Calling counter...');
+						return Dispatcher
+							.call('/good-with-ignore/1.2.3/counter');
+					})
+					.then(ctx => {
+						log(ctx.response);
+						expect(ctx.response).to.equal(1);
+						log('Writing to ignored file "ignoredFile.txt"');
+						fs.writeFileSync(path.join(pluginDir, 'ignoredFile.txt'), 'hello');
+						return sleep(3000);
+					})
+					.then(() => {
+						log('Calling counter again...');
+						return Dispatcher
+							.call('/good-with-ignore/1.2.3/counter');
+					})
+					.then(ctx => {
+						log(ctx.response);
+						expect(ctx.response).to.equal(2);
+
+						log('Writing to non-ignored file "file.txt"');
+						fs.writeFileSync(path.join(pluginDir, 'file.txt'), 'hello');
+						return sleep(3000);
+					})
+					.then(() => {
+						log('Calling counter again...');
+						return Dispatcher
+							.call('/good-with-ignore/1.2.3/counter');
+					})
+					.then(ctx => {
+						log(ctx.response);
+						expect(ctx.response).to.equal(1);
+					})
+					.then(ctx => {
+						log('Unregistering plugin');
+						return pm
+							.call('/unregister', {
+								data: {
+									path: pluginDir
+								}
+							});
+					})
+					.then(() => {
+						log('Done');
+						done();
+					})
+					.catch(done);
+			}, 1000);
+		});
+
 		it('should handle bad plugins', function (done) {
 			this.timeout(10000);
 			this.slow(9000);


### PR DESCRIPTION
https://jira.appcelerator.org/browse/DAEMON-222

- To explicitly call it out 589915b2accd6c6dce8362ac16ffe63e95604eb8 changes the FSWatcher to ignore the change event on Windows, which prevents a file written in 'adir' causing a change event on 'adir', **however** this is also preventing events such as folders being hidden, made read only from propagating through so I think the method of doing this needs to get smarter.
	- Side-note that this change lowers the failures in the unit tests from 25 to 4 so at least there's something good!

- It might be good to expand upon the default in this.ignore https://github.com/ewanharris/appc-daemon/blob/81f71e735b0171f09797bd963660283c6449735e/packages/appcd-plugin/src/plugin.js#L220 to include some extra directories but I'm not sure what is best.

- I believe the implementation of simply blacklisting directory/filename is fine as the FSWatcher in the plugin system does not work recursively, happy to be convinced otherwise