### PR TITLE
Spawn plugin with a cwd of its path, update deps

### DIFF
--- a/packages/appcd-plugin/src/external-plugin.js
+++ b/packages/appcd-plugin/src/external-plugin.js
@@ -424,7 +424,8 @@ export default class ExternalPlugin extends PluginBase {
 						data: {
 							args,
 							options: {
-								env: Object.assign({ FORCE_COLOR: 1 }, process.env)
+								env: Object.assign({ FORCE_COLOR: 1 }, process.env),
+								cwd: this.plugin.path
 							},
 							ipc: true
 						}

--- a/packages/appcd-plugin/test/fixtures/good-with-ignore/index.js
+++ b/packages/appcd-plugin/test/fixtures/good-with-ignore/index.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 console.log('good external plugin required');
 let counter = 0;
 
@@ -6,6 +8,7 @@ module.exports = {
 		appcd.register('/counter', ctx => {
 			counter++;
 			ctx.response = counter;
+			fs.writeFileSync('./counter.txt', counter);
 		});
 	},
 

--- a/packages/appcd-plugin/test/fixtures/good-with-ignore/package.json
+++ b/packages/appcd-plugin/test/fixtures/good-with-ignore/package.json
@@ -5,7 +5,8 @@
 		"name": "good-with-ignore",
 		"inactivityTimeout": 30000,
 		"ignore": [
-			"ignoredFile.txt"
+			"ignoredFile.txt",
+			"counter.txt"
 		]
 	}
 }

--- a/packages/appcd-plugin/test/test-plugin-manager.js
+++ b/packages/appcd-plugin/test/test-plugin-manager.js
@@ -459,6 +459,43 @@ describe('PluginManager', () => {
 			}, 1000);
 		});
 
+		it('should spawn a plugin with a cwd of the plugin path', function (done) {
+			this.timeout(20000);
+			this.slow(19000);
+
+			const sourceDir = path.join(__dirname, 'fixtures', 'good-with-ignore');
+			const pluginDir = makeTempDir();
+
+			fs.copySync(sourceDir, pluginDir);
+
+			pm = new PluginManager();
+
+			setTimeout(() => {
+				pm
+					.call('/register', {
+						data: {
+							path: pluginDir
+						}
+					})
+					.then(() => {
+						log('Calling counter...');
+						return Dispatcher
+							.call('/good-with-ignore/1.2.3/counter');
+					})
+					.then(ctx => {
+						const counterFile = path.join(pluginDir, 'counter.txt');
+						expect(fs.existsSync(counterFile)).to.equal(true);
+						expect(fs.readFileSync(counterFile, { encoding: 'utf8' })).to.equal('1');
+						fs.removeSync(counterFile);
+					})
+					.then(() => {
+						log('Done');
+						done();
+					})
+					.catch(done);
+			}, 1000);
+		});
+
 		it('should not reload a plugin when file is ignored', function (done) {
 			this.timeout(20000);
 			this.slow(19000);


### PR DESCRIPTION
https://jira.appcelerator.org/browse/DAEMON-234

- Spawn plugin with a cwd of its path (with test)
- Update npm deps, namely cli-kit in appcd. For some reason `gulp upgrade` wouldn't update this so I had to edit package.json directly (checking the Jenkins jobs it looks like this was a problem there too). A lot of the noise looks like churn from a registry switch in the yarn lockfiles 🤷‍♂️ 