### PR TITLE
DAEMON-235 and DAEMON-233 - appcd-fswatcher improvements

### DIFF
--- a/packages/appcd-config/test/test-config.js
+++ b/packages/appcd-config/test/test-config.js
@@ -5,6 +5,7 @@ import tmp from 'tmp';
 import { real } from 'appcd-path';
 
 const _tmpDir = tmp.dirSync({
+	mode: '755',
 	prefix: 'appcd-config-test-',
 	unsafeCleanup: true
 }).name;

--- a/packages/appcd-detect/src/detector.js
+++ b/packages/appcd-detect/src/detector.js
@@ -76,7 +76,6 @@ export default class Detector extends EventEmitter {
 			}
 
 			if (depth <= 0) {
-				foundPaths.add(dir);
 				this.logger.log('    No result, hit max depth, returning');
 				return;
 			}

--- a/packages/appcd-detect/test/test-detect-engine.js
+++ b/packages/appcd-detect/test/test-detect-engine.js
@@ -16,6 +16,7 @@ const { log } = appcdLogger('test:appcd:detect');
 const { highlight } = appcdLogger.styles;
 
 const _tmpDir = tmp.dirSync({
+	mode: '755',
 	prefix: 'appcd-detect-test-',
 	unsafeCleanup: true
 }).name;

--- a/packages/appcd-fswatcher/package.json
+++ b/packages/appcd-fswatcher/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "appcd-dispatcher": "^1.0.1",
     "appcd-logger": "^1.0.1",
-    "appcd-path": "^1.0.1",
     "appcd-response": "^1.0.1",
     "appcd-util": "^1.0.1",
     "gawk": "^4.4.5",
@@ -26,6 +25,7 @@
   },
   "devDependencies": {
     "appcd-gulp": "^1.0.1",
+    "appcd-path": "^1.0.1",
     "fs-extra": "^5.0.0",
     "gulp": "^3.9.1",
     "tmp": "^0.0.33"

--- a/packages/appcd-fswatcher/src/fswatcher.js
+++ b/packages/appcd-fswatcher/src/fswatcher.js
@@ -1,3 +1,5 @@
+/* eslint no-confusing-arrow: "off", import/no-mutable-exports: "off" */
+
 import appcdLogger from 'appcd-logger';
 import fs from 'fs';
 import gawk from 'gawk';
@@ -15,6 +17,12 @@ const { pluralize } = appcdLogger;
  * @type {RegExp}
  */
 const rootRegExp = /^(\/|[A-Za-z]+:\\)(.+)?$/;
+
+/**
+ * A counter used to assign a unique number to each `FSWatcher` instance.
+ * @type {Number}
+ */
+let watcherCounter = 0;
 
 /**
  * An emitter that is used to broadcast all FS events for all nodes.
@@ -55,9 +63,10 @@ export const stats = gawk.watch(gawk({
  * @default
  */
 export const DOES_NOT_EXIST = 0;
-export const DIRECTORY = 1;
-export const FILE = 2;
-export const SYMLINK = 4;
+export const DIRECTORY      = 1;
+export const FILE           = 2;
+export const SYMLINK        = 4;
+export const RESTRICTED     = 8;
 
 /**
  * Tracks the state for a directory, file, symlink, or non-existent file and notifies watchers of
@@ -73,125 +82,90 @@ export class Node {
 	 * @access public
 	 */
 	constructor(path, parent) {
-		stats.nodes++;
-		log('Incrementing stats.nodes to ' + stats.nodes);
-
+		/**
+		 * A map of filenames to nodes. Child nodes are paths of interest, but may or may not
+		 * actually exist.
+		 * @type {Object}
+		 */
 		this.children = {};
+
+		/**
+		 * A map of watcher ids to recursive depths relative to this node.
+		 * @type {Object}
+		 */
+		this.depths = {};
+
+		/**
+		 * A list of nodes that symbolically link to this node.
+		 * @type {Set}
+		 */
 		this.links = new Set();
+
+		/**
+		 * The filename of this node.
+		 * @type {String}
+		 */
 		this.name = _path.basename(path) || path;
+
+		/**
+		 * A reference to the parent node.
+		 * @type {?Node}
+		 */
 		this.parent = parent || null;
+
+		/**
+		 * The full path to this node.
+		 * @type {String}
+		 */
 		this.path = this.realPath = path;
-		this.recursive = 0;
+
+		/**
+		 * A list of `FSWatcher` instances that watch this node.
+		 * @type {Set}
+		 */
 		this.watchers = new Set();
+
+		stats.nodes++;
+		// log('Incrementing stats.nodes to %s %s', stats.nodes, highlight(this.path));
+
 		this.stat();
 	}
 
 	/**
-	 * Stats the path and determines if the path is a directory, file, symlink, or non-existent.
+	 * Creates a node for the specified file and adds it as a child to this node.
 	 *
-	 * @access private
+	 * @param {String} filename - The name of the file or directory.
+	 * @param {Boolean} [isAdd] - When `true`, stats the new node and adds it as a child.
+	 * @param {Boolean} [dirOnly] - When `true`, only adds the child node if it's a directory.
+	 * @returns {?Node} The child node.
+	 * @access public
 	 */
-	stat() {
-		try {
-			const lstat = fs.lstatSync(this.path);
-			if (lstat.isDirectory()) {
-				this.type = DIRECTORY;
-			} else if (lstat.isSymbolicLink()) {
-				this.type = SYMLINK;
-				try {
-					const stat = fs.statSync(this.path);
-					this.realPath = fs.realpathSync(this.path);
-					if (stat.isDirectory()) {
-						this.type |= DIRECTORY;
-					} else if (stat.isFile()) {
-						this.type |= FILE;
-					}
-				} catch (e) {
-					// broken symlink, need to read link
-					const link = fs.readlinkSync(this.path);
-					this.realPath = _path.isAbsolute(link) ? link : _path.join(_path.dirname(this.path), link);
-				}
-			} else {
-				this.type = FILE;
-			}
-		} catch (e) {
-			this.type = DOES_NOT_EXIST;
+	addChild(filename, isAdd, dirOnly) {
+		const node = new Node(_path.join(this.path, filename), this);
+
+		if (!dirOnly || node.type & DIRECTORY || node.type & SYMLINK) {
+			log('Creating node for %s', highlight(node.path));
+			node.init(isAdd);
+			this.children[node.name] = node;
+			return node;
 		}
+
+		node.destroy();
+		return null;
 	}
 
 	/**
-	 * Initializes the node by starting the actual fs watch and listing of files when the node is a
-	 * directory, or registers the real path if this node is a symlink.
+	 * Closes this node's native fs watcher.
 	 *
-	 * @param {Boolean} isAdd - When `true` and this node is a directory, it will stat and
-	 * initialize any existing watched child nodes.
-	 * @returns {Node}
 	 * @access private
 	 */
-	init(isAdd) {
-		if (this.type !== DIRECTORY) {
-			/* istanbul ignore if */
-			if (this.fswatcher) {
-				// NOTE: This should never happen and is very difficult to reproduce in a unit test
-				// because there should never be a time where the `type` changes from a directory to
-				// a file or symlink without it first being deleted. If there was a glitch and the
-				// delete fs event was dropped or there was a race condition with another process,
-				// then it's possible that the fswatcher is still active and then this code will
-				// save the day.
-				this.fswatcher.close();
-				delete this.fswatcher;
-				stats.fswatchers--;
-			}
-
-			if (this.type & SYMLINK) {
-				this.link = register(this.realPath);
-				this.link.links.add(this);
-			}
-
-		} else if (!this.fswatcher) {
-			log('Initializing fs watcher: %s', highlight(this.path));
-			this.fswatcher = fs.watch(this.path, { persistent: true }, this.onFSEvent.bind(this));
-			stats.fswatchers++;
-
-			const now = Date.now();
-			this.files = new Map();
-
-			for (const filename of fs.readdirSync(this.path)) {
-				const file = _path.join(this.path, filename);
-				this.files.set(filename, now);
-
-				if (isAdd) {
-					const child = this.children[filename];
-					if (child) {
-						child.stat();
-						child.init(true);
-					}
-
-					this.notify({
-						action: 'add',
-						filename,
-						file
-					}, true);
-				}
-			}
-
-			if (isAdd) {
-				for (const node of this.links) {
-					node.notify({
-						action: 'change',
-						filename: node.name,
-						file: node.path
-					});
-				}
-			}
+	closeFSWatcher() {
+		if (this.fswatcher) {
+			this.fswatcher.close();
+			delete this.fswatcher;
+			stats.fswatchers--;
+			log('Closed fs watcher: %s (%s)', highlight(this.path), stats.fswatchers);
 		}
-
-		let type = this.type & SYMLINK ? 'l' : '';
-		type += this.type & DIRECTORY ? 'd' : this.type & FILE ? 'f' : '?';
-		const files = this.files ? `(${pluralize('file', this.files.size, true)})` : '';
-		log('Initialized node: %s %s %s', highlight(this.path), green(`[${type}]`), files);
-
-		return this;
 	}
 
 	/**
@@ -213,14 +187,9 @@ export class Node {
 			}
 
 			stats.nodes--;
-			log('Decrementing stats.nodes to ' + stats.nodes);
+			// log('Decrementing stats.nodes to %s %s', stats.nodes, highlight(this.path));
 
-			if (this.fswatcher) {
-				// log('destroy() Closing fs watcher: %s', highlight(this.path));
-				this.fswatcher.close();
-				delete this.fswatcher;
-				stats.fswatchers--;
-			}
+			this.closeFSWatcher();
 
 			if (this.files) {
 				this.files.clear();
@@ -249,18 +218,6 @@ export class Node {
 	/**
 	 * Adds a node as a child and automatically sets this node as its parent.
 	 *
-	 * @param {Node} node - The child node.
-	 * @returns {Node} The child node.
-	 * @access public
-	 */
-	addChild(node) {
-		node.parent = this;
-		return this.children[node.name] = node;
-	}
-
-	/**
-	 * Adds a node as a child and automatically sets this node as its parent.
-	 *
 	 * @param {String} name - The child file or directory name to get.
 	 * @returns {Node} The child node or `null` if not found.
 	 * @access public
@@ -270,162 +227,189 @@ export class Node {
 	}
 
 	/**
-	 * Adds the specified watcher to this node.
+	 * Initializes the node by starting the actual fs watch and listing of files when the node is a
+	 * directory, or registers the real path if this node is a symlink.
 	 *
-	 * @param {FSWatcher} watcher - The FSWatcher instance.
-	 * @returns {Node}
-	 * @access public
-	 */
-	watch(watcher) {
-		if (!this.watchers.has(watcher)) {
-			stats.watchers++;
-			this.watchers.add(watcher);
-
-			if (watcher.recursive) {
-				this.recursive++;
-				this.recursiveWatch(watcher.recursive === Infinity ? Infinity : watcher.recursive);
-			}
-		}
-		return this;
-	}
-
-	/**
-	 * Recursively descends all child nodes and increments the recursive counter.
-	 *
-	 * @param {Number} depth - The depth to stop recursively watching.
+	 * @param {Boolean} isAdd - When `true` and this node is a directory, it will stat and
+	 * initialize any existing watched child nodes.
+	 * @returns {Node|null} Returns `null` if the node is restricted, otherwise a reference to
+	 * itself.
 	 * @access private
 	 */
-	recursiveWatch(depth) {
-		if (this.type & DIRECTORY && this.files && depth > 0) {
-			if (depth !== Infinity) {
-				depth--;
-			}
+	init(isAdd) {
+		const isDir      = this.type & DIRECTORY;
+		const isFile     = this.type & FILE;
+		const isSymlink  = this.type & SYMLINK;
 
-			for (const [ filename ] of this.files) {
-				let child = this.children[filename];
-				if (!child) {
-					child = new Node(_path.join(this.path, filename), this);
-					if (child.type !== DIRECTORY && child.type !== SYMLINK) {
-						stats.nodes--;
-						log('Decrementing stats.nodes to ' + stats.nodes);
-						continue;
+		if (!isDir) {
+			this.closeFSWatcher();
+		}
+
+		// if we have a symlink, register the real path and add it's real node to this node's links
+		if (isSymlink) {
+			this.link = register(this.realPath);
+			this.link.links.add(this);
+
+		// if we have a directory, then initialize the listing and recurse if necessary
+		} else if (isDir) {
+			// init the recursion depths
+			this.depths = {};
+			if (this.parent) {
+				for (const [ id, depth ] of Object.entries(this.parent.depths)) {
+					if (depth > 0) {
+						this.depths[id] = depth === Infinity ? Infinity : depth - 1;
 					}
-					this.children[filename] = child.init();
 				}
-				child.recursiveWatch(depth);
+			}
+
+			// get the directory listing and init the fs watcher
+			let listing = [];
+			try {
+				listing = fs.readdirSync(this.path);
+
+				if (!this.fswatcher) {
+					this.fswatcher = fs.watch(this.path, { persistent: true }, this.onFSEvent.bind(this));
+					stats.fswatchers++;
+					log('Initialized fs watcher: %s (%s)', highlight(this.path), stats.fswatchers);
+				}
+
+				this.type &= ~RESTRICTED;
+			} catch (e) {
+				if (e.code === 'EACCES') {
+					this.type |= RESTRICTED;
+				} else {
+					throw e;
+				}
+			}
+
+			// all directory nodes must have a clean files map
+			if (this.files instanceof Map) {
+				this.files.clear();
+			} else {
+				this.files = new Map();
+			}
+
+			// if this node is now restricted, we need to clean up
+			if (this.type & RESTRICTED) {
+				log('%s is restricted, removing children as we can no longer see them', highlight(this.path));
+
+				const restrictAndCheckIfEmpty = node => {
+					let empty = !node.watchers.size;
+
+					node.type |= RESTRICTED;
+
+					for (const [ name, child ] of Object.entries(node.children)) {
+						// need to determine if the child can be destroyed
+						if (restrictAndCheckIfEmpty(child)) {
+							child.destroy();
+							delete node.children[name];
+						} else {
+							empty = false;
+						}
+					}
+
+					return empty;
+				};
+
+				// mark all children as restricted
+				// if the child has no watchers, it can be removed
+				restrictAndCheckIfEmpty(this);
+
+				// make sure we're cleaned up
+				this.closeFSWatcher();
+
+			// node is not restricted
+			} else {
+				log('%s is not restricted, listing and creating child nodes', highlight(this.path));
+				const now = Date.now();
+
+				// loop over the listing and populate files
+				// if this is an 'add', then initialize the child node
+				for (const filename of listing) {
+					const file = _path.join(this.path, filename);
+
+					this.files.set(filename, now);
+
+					if (isAdd) {
+						let child = this.children[filename];
+						if (child) {
+							child.stat();
+							child.init(true);
+						} else if (Object.values(this.depths).some(depth => depth)) {
+							this.addChild(filename, true, true);
+						}
+
+						this.notify({
+							action: 'add',
+							filename,
+							file
+						}, true);
+					}
+				}
+
+				// if this is an add, then notify all links that this node changed
+				if (isAdd) {
+					for (const node of this.links) {
+						node.notify({
+							action: 'change',
+							filename: node.name,
+							file: node.path
+						});
+					}
+				}
 			}
 		}
-	}
 
-	/**
-	 * Removes the specified watcher from this node.
-	 *
-	 * @param {FSWatcher} watcher - The FSWatcher instance.
-	 * @returns {Node}
-	 * @access public
-	 */
-	unwatch(watcher) {
-		if (this.watchers.has(watcher)) {
-			stats.watchers--;
-			this.watchers.delete(watcher);
+		let type = isSymlink ? 'l' : '';
+		type += isDir ? 'd' : isFile ? 'f' : '?';
+		const files = this.files ? `(${pluralize('file', this.files.size, true)})` : '';
+		log('Initialized node: %s %s %s', highlight(this.path), green(`[${type}]`), files);
 
-			if (watcher.recursive) {
-				this.recursive--;
-				this.recursiveUnwatch(watcher.recursive === Infinity ? Infinity : watcher.recursive - 1);
-			}
-		}
 		return this;
 	}
 
 	/**
-	 * Recursively descends all child nodes and decrements the recursive counter.
+	 * Detects if the node is active by checking if there are any watchers, if any parent node is
+	 * watching recursively, or if any child node has active watchers.
 	 *
-	 * @param {Number} depth - The depth to stop recursively watching.
-	 * @access private
+	 * @param {Boolean} recursive - When `true`, checks if any parent node is recursively watching
+	 * the current node.
+	 * @returns {Boolean}
+	 * @access public
 	 */
-	recursiveUnwatch(depth) {
-		if (this.type & DIRECTORY && this.files) {
-			for (const [ filename ] of this.files) {
-				let child = this.children[filename];
-				if (child) {
-					child.recursiveUnwatch(depth === Infinity ? Infinity : depth - 1);
-				}
-			}
+	isActive(recursive) {
+		if (this.watchers.size) {
+			log('%s is active with %s', highlight(this.realPath), pluralize('watcher', this.watchers.size, true));
+			return true;
 		}
+		if (recursive && this.isParentRecursive()) {
+			log('%s is active because of a recursive parent', highlight(this.realPath));
+			return true;
+		}
+		if (this.type & DIRECTORY && (this.link && this.link.isActive() || Object.values(this.children).some(child => child.isActive()))) {
+			log('%s is active because child has a watcher', highlight(this.realPath));
+			return true;
+		}
+		return false;
 	}
 
 	/**
-	 * Callback for Node's `fs.watch()` that processes the incoming fs event.
+	 * Checks if any parents are recursively watching this node.
 	 *
-	 * @param {String} event - The event name. This value is either `rename` or `change` and is
-	 * mostly useless.
-	 * @param {String} filename - The name of the file that triggered the event.
-	 * @access private
+	 * @returns {Boolean}
+	 * @access public
 	 */
-	onFSEvent(event, filename) {
-		// check that the changed file hasn't been deleted during notification
-		if (filename === null) {
-			return;
-		}
+	isParentRecursive() {
+		return this.parent && (this.parent.isRecursive || this.parent.isParentRecursive());
+	}
 
-		try {
-			// sanity check that this path still exists because apparently Linux
-			// will let the watcher know that itself was deleted
-			fs.lstatSync(this.path);
-		} catch (e) {
-			return;
-		}
-
-		const prev = this.files && this.files.get(filename) || null;
-		const evt = {
-			action: prev ? 'change' : 'add',
-			filename,
-			file: _path.join(this.path, filename)
-		};
-		const now = Date.now();
-		let isFile = false;
-
-		try {
-			const stat = fs.lstatSync(evt.file);
-
-			if (process.platform === 'win32'
-				&& event === 'change'
-				&& evt.action === 'change'
-				&& stat.isDirectory()
-			) {
-				// This will drop also events where there is a permission change on the folder,
-				// tracked as https://jira.appcelerator.org/browse/DAEMON-232 - EH 02/08/18
-				log('Dropping Windows event for change on a directory when there is a change to a file');
-				return;
-			}
-
-			isFile = stat.isFile();
-			this.files.set(filename, [ evt.action, now ]);
-		} catch (e) {
-			// file was deleted
-			evt.action = 'delete';
-			if (this.files) {
-				this.files.delete(filename);
-			}
-		}
-
-		if (prev && evt.action !== 'delete' && (prev[1] > 0 && (now - prev[1]) < 16)) {
-			log('Dropping redundant event: %s %s → %s', green(`[${evt.action}]`), highlight(this.path), highlight(filename));
-			return;
-		}
-
-		log('FS Event: %s %s → %s', green(`[${evt.action}]`), highlight(this.path), highlight(filename));
-
-		let child = this.children[filename];
-		if (child) {
-			log('Notifying child node: %s', highlight(filename));
-			child.notifyChild(evt);
-		} else if (evt.action === 'add' && !isFile && (this.recursive > 0 || this.isParentRecursive())) {
-			log('Creating node for %s', highlight(evt.file));
-			this.children[filename] = new Node(evt.file, this).init();
-		}
-
-		this.notify(evt, true);
+	/**
+	 * Determines if this node is subject to recursion.
+	 *
+	 * @type {Boolean}
+	 */
+	get isRecursive() {
+		return Object.keys(this.depths).length > 0;
 	}
 
 	/**
@@ -439,7 +423,7 @@ export class Node {
 	 * @access private
 	 */
 	notify(evt, isCurrentNode, depth = 0) {
-		if ((isCurrentNode && this.watchers.size) || (!isCurrentNode && this.recursive > 0)) {
+		if ((isCurrentNode && this.watchers.size) || (!isCurrentNode && this.isRecursive)) {
 			log('Notifying %s %s: %s → %s', green(this.watchers.size), pluralize('watcher', this.watchers.size), highlight(this.path), highlight(evt.filename));
 			for (const watcher of this.watchers) {
 				if (watcher.recursive === 0 || watcher.recursive === Infinity || watcher.recursive > depth) {
@@ -458,25 +442,6 @@ export class Node {
 			this.parent.notify(evt, false, depth + 1);
 		} else {
 			rootEmitter.emit('change', evt);
-		}
-	}
-
-	/**
-	 * Called when the parent is receives an event related to this node. When the event was an
-	 * `add`, it will stat and init this node. When the event is a `delete`, it stops watching the
-	 * now non-existent directory/file.
-	 *
-	 * @param {Object} evt - The fs event object.
-	 * @access private
-	 */
-	notifyChild(evt) {
-		if (evt.action === 'delete') {
-			this.onDeleted(evt);
-			this.notifyChildWatchers(evt);
-		} else {
-			this.notifyChildWatchers(evt);
-			this.stat();
-			this.init(evt.action === 'add');
 		}
 	}
 
@@ -512,17 +477,12 @@ export class Node {
 	 * @access private
 	 */
 	onDeleted(evt) {
-		if (this.fswatcher) {
-			// log('onDeleted() Closing fs watcher: %s', highlight(this.path));
-			this.fswatcher.close();
-			delete this.fswatcher;
-			stats.fswatchers--;
-		}
-
 		this.type = DOES_NOT_EXIST;
 
+		this.closeFSWatcher();
+
 		const children = Object.values(this.children);
-		if (children) {
+		if (children.length) {
 			log('Notifying %s %s they were deleted: %s',
 				green(children.length),
 				pluralize('child', children.length),
@@ -530,6 +490,10 @@ export class Node {
 
 			for (const child of children) {
 				child.onDeleted(evt);
+				if (!child.watchers.size && !Object.keys(child.children).length) {
+					child.destroy();
+					delete this.children[child.name];
+				}
 			}
 		}
 
@@ -573,38 +537,209 @@ export class Node {
 	}
 
 	/**
-	 * Checks if any parents are recursively watching this node.
+	 * Callback for Node's `fs.watch()` that processes the incoming fs event.
 	 *
-	 * @returns {Boolean}
-	 * @access public
+	 * @param {String} event - The event name. This value is either `rename` or `change` and is
+	 * mostly useless.
+	 * @param {String} filename - The name of the file that triggered the event.
+	 * @access private
 	 */
-	isParentRecursive() {
-		return this.parent && (this.parent.recursive > 0 || this.parent.isParentRecursive());
+	onFSEvent(event, filename) {
+		// check that the changed file hasn't been deleted during notification
+		/* istanbul ignore if */
+		if (filename === null) {
+			return;
+		}
+
+		try {
+			// sanity check that this path still exists because apparently Linux
+			// will let the watcher know that itself was deleted
+			fs.lstatSync(this.path);
+		} catch (e) {
+			return;
+		}
+
+		const prev = this.files && this.files.get(filename) || null;
+		const evt = {
+			action: prev ? 'change' : 'add',
+			filename,
+			file: _path.join(this.path, filename)
+		};
+		const now = Date.now();
+		let isDir = false;
+		let child = this.children[filename];
+
+		try {
+			const stat = fs.lstatSync(evt.file);
+			isDir = stat.isDirectory();
+
+			if (process.platform === 'win32'
+				&& event === 'change'
+				&& evt.action === 'change'
+				&& isDir
+			) {
+				// This will drop also events where there is a permission change on the folder,
+				// tracked as https://jira.appcelerator.org/browse/DAEMON-232 - EH 02/08/18
+				log('Dropping Windows event for change on a directory when there is a change to a file');
+				return;
+			}
+
+			this.files.set(filename, [ evt.action, now ]);
+		} catch (e) {
+			// file was deleted
+			evt.action = 'delete';
+			if (this.files) {
+				this.files.delete(filename);
+			}
+		}
+
+		if (prev && evt.action !== 'delete' && (prev[1] > 0 && (now - prev[1]) < 16)) {
+			log('Dropping redundant event: %s %s → %s', green(`[${evt.action}]`), highlight(this.path), highlight(filename));
+			return;
+		}
+
+		log('FS Event: %s %s → %s', green(`[${evt.action}]`), highlight(this.path), highlight(filename));
+
+		if (child) {
+			log('Notifying child node: %s', highlight(filename));
+			if (evt.action === 'delete') {
+				child.onDeleted(evt);
+				child.notifyChildWatchers(evt);
+				if (!child.watchers.size && !Object.keys(child.children).length) {
+					delete this.children[child.name];
+					child.destroy();
+				}
+			} else {
+				child.stat();
+				child.notifyChildWatchers(evt);
+				child.init(true);
+			}
+		} else if (evt.action === 'add' && (this.isRecursive || this.isParentRecursive())) {
+			this.addChild(filename, true, true);
+		}
+
+		this.notify(evt, true);
 	}
 
 	/**
-	 * Detects if the node is active by checking if there are any watchers, if any parent node is
-	 * watching recursively, or if any child node has active watchers.
+	 * Recursively descends all child nodes and decrements the recursive counter.
 	 *
-	 * @param {Boolean} recursive - When `true`, checks if any parent node is recursively watching
-	 * the current node.
-	 * @returns {Boolean}
+	 * @param {FSWatcher} watcher - The FSWatcher instance.
+	 * @param {Number} depth - The depth to stop recursively watching.
+	 * @access private
+	 */
+	recursiveUnwatch(watcher, depth) {
+		delete this.depths[watcher.id];
+
+		if (this.type & DIRECTORY && this.files) {
+			for (const [ filename ] of this.files) {
+				let child = this.children[filename];
+				if (child) {
+					child.recursiveUnwatch(watcher, depth === Infinity ? Infinity : depth - 1);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Recursively descends all child nodes and increments the recursive counter.
+	 *
+	 * @param {Number} depth - The depth to stop recursively watching.
+	 * @access private
+	 */
+	recursiveWatch(depth) {
+		if (this.type & DIRECTORY && this.files && depth > 0) {
+			if (depth !== Infinity) {
+				depth--;
+			}
+
+			for (const [ filename ] of this.files) {
+				let child = this.children[filename];
+				if (!child) {
+					child = new Node(_path.join(this.path, filename), this);
+					if (!(child.type & DIRECTORY) && !(child.type & SYMLINK)) {
+						stats.nodes--;
+						// log('Decrementing stats.nodes to %s %s', stats.nodes, highlight(this.path));
+						continue;
+					}
+					this.children[filename] = child;
+					child.init();
+				}
+				child.recursiveWatch(depth);
+			}
+		}
+	}
+
+	/**
+	 * Stats the path and determines if the path is a directory, file, symlink, or non-existent.
+	 * Also checks if the file can be accessed or if its restricted.
+	 *
+	 * @access private
+	 */
+	stat() {
+		try {
+			const lstat = fs.lstatSync(this.path);
+			if (lstat.isDirectory()) {
+				this.type = DIRECTORY;
+			} else if (lstat.isSymbolicLink()) {
+				this.type = SYMLINK;
+				try {
+					const stat = fs.statSync(this.path);
+					this.realPath = fs.realpathSync(this.path);
+					if (stat.isDirectory()) {
+						this.type |= DIRECTORY;
+					} else if (stat.isFile()) {
+						this.type |= FILE;
+					}
+				} catch (e) {
+					// broken symlink, need to read link
+					const link = fs.readlinkSync(this.path);
+					this.realPath = _path.isAbsolute(link) ? link : _path.join(_path.dirname(this.path), link);
+				}
+			} else {
+				this.type = FILE;
+			}
+		} catch (e) {
+			this.type = DOES_NOT_EXIST;
+		}
+	}
+
+	/**
+	 * Removes the specified watcher from this node.
+	 *
+	 * @param {FSWatcher} watcher - The FSWatcher instance.
+	 * @returns {Node}
 	 * @access public
 	 */
-	isActive(recursive) {
-		if (this.watchers.size) {
-			log('%s is active with %s', highlight(this.realPath), pluralize('watcher', this.watchers.size, true));
-			return true;
+	unwatch(watcher) {
+		if (this.watchers.has(watcher)) {
+			stats.watchers--;
+			this.watchers.delete(watcher);
+			if (watcher.recursive) {
+				this.recursiveUnwatch(watcher, watcher.recursive === Infinity ? Infinity : watcher.recursive - 1);
+			}
 		}
-		if (recursive && this.isParentRecursive()) {
-			log('%s is active because of a recursive parent', highlight(this.realPath));
-			return true;
+		return this;
+	}
+
+	/**
+	 * Adds the specified watcher to this node.
+	 *
+	 * @param {FSWatcher} watcher - The FSWatcher instance.
+	 * @returns {Node}
+	 * @access public
+	 */
+	watch(watcher) {
+		if (!this.watchers.has(watcher)) {
+			stats.watchers++;
+			this.watchers.add(watcher);
+
+			if (watcher.recursive) {
+				this.depths[watcher.id] = watcher.recursive;
+				this.recursiveWatch(watcher.recursive === Infinity ? Infinity : watcher.recursive);
+			}
 		}
-		if (this.type & DIRECTORY && (this.link && this.link.isActive() || Object.values(this.children).some(child => child.isActive()))) {
-			log('%s is active because child has a watcher', highlight(this.realPath));
-			return true;
-		}
-		return false;
+		return this;
 	}
 }
 
@@ -645,6 +780,12 @@ export class FSWatcher extends EventEmitter {
 		this.path = path;
 
 		/**
+		 * The unique id for this watcher instance.
+		 * @type {Number}
+		 */
+		this.id = watcherCounter++;
+
+		/**
 		 * The path to watch.
 		 * @type {Number}
 		 */
@@ -663,19 +804,12 @@ export class FSWatcher extends EventEmitter {
 			}
 		}
 
+		/**
+		 * The node associated with the last segment of the specified path. This property is used to
+		 * determine if the this `FSWatcher` instance is initialized and watching for fs events.
+		 * @type {Node}
+		 */
 		this.opened = !!register(path, this);
-	}
-
-	/**
-	 * Re-opens the watcher.
-	 *
-	 * @access public
-	 */
-	open() {
-		if (this.opened) {
-			throw new Error('Already open');
-		}
-		this.opened = !!register(this.path, this);
 	}
 
 	/**
@@ -688,6 +822,18 @@ export class FSWatcher extends EventEmitter {
 		const result = this.opened && unregister(this.path, this);
 		this.opened = false;
 		return result;
+	}
+
+	/**
+	 * Re-opens the watcher.
+	 *
+	 * @access public
+	 */
+	open() {
+		if (this.opened) {
+			throw new Error('Already open');
+		}
+		this.opened = !!register(this.path, this);
 	}
 }
 
@@ -719,10 +865,11 @@ function parsePath(path) {
 }
 
 /**
- * Registers a watcher to the specified path.
+ * Initializes all nodes in the specified `path`, then if applicable it will register the specified
+ * `FSWatcher` instance with the last node in the `path`.
  *
  * @param {String} path - The path to watch.
- * @param {FSWatcher} watcher - The FSWatcher instance.
+ * @param {FSWatcher} [watcher] - The `FSWatcher` instance.
  * @returns {Node}
  */
 export function register(path, watcher) {
@@ -752,7 +899,7 @@ export function register(path, watcher) {
 		if (child) {
 			node = child;
 		} else {
-			node = node.addChild(new Node(_path.join(node.path, segment)).init());
+			node = node.addChild(segment);
 		}
 		if (node.link) {
 			node = node.link;
@@ -882,7 +1029,11 @@ export function renderTree(node, depth = 0, parent = []) {
 		}
 		details.push(pluralize('watcher', node.watchers.size, true));
 		details.push(pluralize('link', node.links.size, true));
-		details.push(`${node.recursive} recursion`);
+		const recursive = Object.keys(node.depths).length;
+		details.push(`${recursive} recursion${recursive ? ` [depths: ${Object.values(node.depths).map(v => v === Infinity ? '∞' : v).join(' ')}]` : ''}`);
+		if (node.type & RESTRICTED) {
+			details.push('restricted');
+		}
 		meta.push(` (${details.join(', ')})`);
 
 		str += ` ${indent}${symbol}${!hasChildren ? '─' : !depth && !i ? '┌' : '┬'} ${green(`[${type}]`)} ${highlight(name)}${meta.join(' ')}\n`;

--- a/packages/appcd-fswatcher/src/fswatcher.js
+++ b/packages/appcd-fswatcher/src/fswatcher.js
@@ -457,7 +457,7 @@ export class Node {
 		if ((isCurrentNode && this.watchers.size) || (!isCurrentNode && this.isRecursive)) {
 			log('Notifying %s %s: %s → %s', green(this.watchers.size), pluralize('watcher', this.watchers.size), highlight(this.path), highlight(evt.filename));
 			for (const watcher of this.watchers) {
-				if (watcher.recursive === 0 || watcher.recursive === Infinity || watcher.recursive > depth) {
+				if (watcher.recursive === 0 || watcher.recursive === Infinity || watcher.recursive >= depth) {
 					try {
 						watcher.emit('change', evt);
 					} catch (err) {

--- a/packages/appcd-fswatcher/test/after.js
+++ b/packages/appcd-fswatcher/test/after.js
@@ -1,0 +1,1 @@
+require('./restricted').after();

--- a/packages/appcd-fswatcher/test/restricted.js
+++ b/packages/appcd-fswatcher/test/restricted.js
@@ -1,0 +1,57 @@
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+exports.RESTRICTED_TESTS_RUN      = 0;
+exports.RESTRICTED_TESTS_NOT_ROOT = 1;
+exports.RESTRICTED_TESTS_BAD_OS   = 2;
+exports.RESTRICTED_TESTS_NO_USER  = 3;
+exports.RESTRICTED_TESTS_BAD_USER = 4;
+
+exports.after          = after;
+exports.getDescription = getDescription;
+exports.getUser        = getUser;
+exports.shouldRunTests = shouldRunTests;
+
+const user = process.env.TEST_USER || process.env.SUDO_USER;
+let state = exports.RESTRICTED_TESTS_RUN;
+
+if (process.getuid() !== 0) {
+	state = exports.RESTRICTED_TESTS_NOT_ROOT;
+} else if (!process.seteuid) {
+	state = exports.RESTRICTED_TESTS_BAD_OS;
+} else if (!user) {
+	state = exports.RESTRICTED_TESTS_NO_USER;
+} else if (user === 'root') {
+	state = exports.RESTRICTED_TESTS_BAD_USER;
+}
+
+function after() {
+	if (shouldRunTests() && process.env.SUDO_USER) {
+		const cwd = path.dirname(__dirname);
+		const args = [ '-R', process.env.SUDO_USER, '.nyc_output', 'coverage' ];
+		console.log(`appcd-gulp after: CWD=${cwd} chown ${args.join(' ')}`);
+		spawnSync('chown', args, { cwd });
+	}
+}
+
+function getDescription() {
+	switch (state) {
+		case exports.RESTRICTED_TESTS_NOT_ROOT:
+			return ' (test must be run as root)';
+		case exports.RESTRICTED_TESTS_BAD_OS:
+			return ' (test cannot be run on Windows)';
+		case exports.RESTRICTED_TESTS_NO_USER:
+			return ' (TEST_USER/SUDO_USER env var not set)';
+		case exports.RESTRICTED_TESTS_BAD_USER:
+			return ' (TEST_USER/SUDO_USER must not be root)';
+	}
+	return '';
+}
+
+function getUser() {
+	return user;
+}
+
+function shouldRunTests() {
+	return state === exports.RESTRICTED_TESTS_RUN;
+}

--- a/packages/appcd-fswatcher/test/restricted.js
+++ b/packages/appcd-fswatcher/test/restricted.js
@@ -16,10 +16,10 @@ const { TEST_USER, SUDO_USER, SUDO_UID, SUDO_GID } = process.env;
 const user = TEST_USER || SUDO_USER;
 let state = exports.RESTRICTED_TESTS_RUN;
 
-if (process.getuid() !== 0) {
-	state = exports.RESTRICTED_TESTS_NOT_ROOT;
-} else if (!process.seteuid) {
+if (!process.getuid || !process.seteuid) {
 	state = exports.RESTRICTED_TESTS_BAD_OS;
+} else if (process.getuid() !== 0) {
+	state = exports.RESTRICTED_TESTS_NOT_ROOT;
 } else if (!user) {
 	state = exports.RESTRICTED_TESTS_NO_USER;
 } else if (user === 'root') {

--- a/packages/appcd-fswatcher/test/restricted.js
+++ b/packages/appcd-fswatcher/test/restricted.js
@@ -12,7 +12,8 @@ exports.getDescription = getDescription;
 exports.getUser        = getUser;
 exports.shouldRunTests = shouldRunTests;
 
-const user = process.env.TEST_USER || process.env.SUDO_USER;
+const { TEST_USER, SUDO_USER, SUDO_UID, SUDO_GID } = process.env;
+const user = TEST_USER || SUDO_USER;
 let state = exports.RESTRICTED_TESTS_RUN;
 
 if (process.getuid() !== 0) {
@@ -26,9 +27,10 @@ if (process.getuid() !== 0) {
 }
 
 function after() {
-	if (shouldRunTests() && process.env.SUDO_USER) {
+	const owner = (SUDO_UID || SUDO_USER) + (SUDO_GID ? `:${SUDO_GID}` : '');
+	if (shouldRunTests() && owner) {
 		const cwd = path.dirname(__dirname);
-		const args = [ '-R', process.env.SUDO_USER, '.nyc_output', 'coverage' ];
+		const args = [ '-R', owner, '.nyc_output', 'coverage' ];
 		console.log(`appcd-gulp after: CWD=${cwd} chown ${args.join(' ')}`);
 		spawnSync('chown', args, { cwd });
 	}

--- a/packages/appcd-fswatcher/test/test-fswatch-manager.js
+++ b/packages/appcd-fswatcher/test/test-fswatch-manager.js
@@ -11,6 +11,7 @@ const log = appcdLogger('test:appcd:fswatcher:manager').log;
 const { highlight } = appcdLogger.styles;
 
 const _tmpDir = tmp.dirSync({
+	mode: '755',
 	prefix: 'appcd-fswatcher-test-',
 	unsafeCleanup: true
 }).name;

--- a/packages/appcd-fswatcher/test/test-fswatcher.js
+++ b/packages/appcd-fswatcher/test/test-fswatcher.js
@@ -152,7 +152,7 @@ describe('FSWatcher', () => {
 					log(renderTree());
 					log('Writing %s', highlight(filename));
 					fs.writeFileSync(filename, 'foo!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should close and re-open watcher', function (done) {
@@ -213,7 +213,7 @@ describe('FSWatcher', () => {
 
 					log('Writing %s', highlight(filename));
 					fs.writeFileSync(filename, 'foo!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should watch an existing directing for a new file that is changed', done => {
@@ -245,8 +245,8 @@ describe('FSWatcher', () => {
 
 					setTimeout(() => {
 						fs.appendFileSync(filename, '\nbar!');
-					}, 100);
-				}, 100);
+					}, 150);
+				}, 150);
 			});
 
 			it('should watch a directory that does not exist', function (done) {
@@ -285,8 +285,8 @@ describe('FSWatcher', () => {
 						log(renderTree());
 						log('Writing %s', highlight(filename));
 						fs.writeFileSync(filename, 'foo!');
-					}, 100);
-				}, 100);
+					}, 150);
+				}, 150);
 			});
 
 			it('should unwatch a directory', function (done) {
@@ -318,7 +318,7 @@ describe('FSWatcher', () => {
 										expect(roots).to.deep.equal({});
 										done();
 									}, 1000);
-								}, 100);
+								}, 150);
 								counter++;
 							} else if (counter === 2) {
 								done(new Error('Expected onChange to only fire once'));
@@ -331,7 +331,7 @@ describe('FSWatcher', () => {
 					counter++;
 					log('Writing %s', highlight(filename));
 					fs.writeFileSync(filename, 'foo!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should watch a directory that is deleted and recreated', function (done) {
@@ -385,7 +385,7 @@ describe('FSWatcher', () => {
 
 											log('Writing %s', highlight(barFile));
 											fs.writeFileSync(barFile, 'bar again!');
-										}, 100);
+										}, 150);
 										break;
 
 									case 4:
@@ -406,7 +406,7 @@ describe('FSWatcher', () => {
 						.once('error', done);
 
 					fs.writeFileSync(barFile, 'bar!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should have two watchers watching the same directory and unwatch them', function (done) {
@@ -477,7 +477,7 @@ describe('FSWatcher', () => {
 				setTimeout(() => {
 					log('Writing %s', highlight(filename));
 					fs.writeFileSync(filename, 'foo!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should close and re-watch a directory', function (done) {
@@ -518,7 +518,7 @@ describe('FSWatcher', () => {
 					} catch (e) {
 						done(e);
 					}
-				}, 100);
+				}, 150);
 			});
 		});
 
@@ -544,7 +544,7 @@ describe('FSWatcher', () => {
 				setTimeout(() => {
 					log(`Appending to ${filename}`);
 					fs.appendFileSync(filename, '\nbar!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should watch a file that does not exist', done => {
@@ -569,7 +569,7 @@ describe('FSWatcher', () => {
 				setTimeout(() => {
 					counter++;
 					fs.writeFileSync(filename, 'foo!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should unwatch a file', function (done) {
@@ -591,7 +591,7 @@ describe('FSWatcher', () => {
 								expect(evt.file).to.equal(real(filename));
 								setTimeout(() => {
 									fs.appendFileSync(filename, '\nbar!');
-								}, 100);
+								}, 150);
 							} else if (counter === 2) {
 								expect(evt.action).to.equal('change');
 								expect(evt.file).to.equal(real(filename));
@@ -610,7 +610,7 @@ describe('FSWatcher', () => {
 											done(e);
 										}
 									}, 1000);
-								}, 100);
+								}, 150);
 							} else {
 								done(new Error('Expected onChange to only fire once'));
 							}
@@ -623,7 +623,7 @@ describe('FSWatcher', () => {
 					counter++;
 					log('Writing %s', highlight(filename));
 					fs.writeFileSync(filename, 'foo!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should watch a file that is deleted and recreated', function (done) {
@@ -657,7 +657,7 @@ describe('FSWatcher', () => {
 
 									setTimeout(() => {
 										fs.writeFileSync(filename, 'bar again!');
-									}, 100);
+									}, 150);
 
 								} else if (counter === 3) {
 									expect(evt.action).to.equal('add');
@@ -670,7 +670,7 @@ describe('FSWatcher', () => {
 
 					log('Appending to %s', highlight(filename));
 					fs.appendFileSync(filename, '\nbar!');
-				}, 100);
+				}, 150);
 			});
 		});
 
@@ -732,7 +732,7 @@ describe('FSWatcher', () => {
 					log(renderTree());
 					log('Creating bar directory: %s', highlight(barDir));
 					fs.mkdirsSync(barDir);
-				}, 100);
+				}, 150);
 			});
 
 			it('should recursively watch for changes in new nested directories', function (done) {
@@ -794,7 +794,7 @@ describe('FSWatcher', () => {
 					log(renderTree());
 					log('Creating foo directory: %s', highlight(fooDir));
 					fs.mkdirsSync(fooDir);
-				}, 100);
+				}, 150);
 			});
 
 			it('should fire an event for two watcher down same path', function (done) {
@@ -843,7 +843,7 @@ describe('FSWatcher', () => {
 					log(renderTree());
 					log('Writing %s', highlight(bazFile));
 					fs.writeFileSync(bazFile, 'baz!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should unwatch recursive directory watcher', function (done) {
@@ -877,7 +877,7 @@ describe('FSWatcher', () => {
 					log(renderTree());
 					log('Appending to %s', highlight(filename));
 					fs.appendFileSync(filename, 'more baz!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should throw error if trying to recursively watch root', () => {
@@ -935,7 +935,7 @@ describe('FSWatcher', () => {
 
 					function checkEvent() {
 						try {
-							if (index < 2) {
+							if (index <= 2) {
 								if (!lastEvt) {
 									throw new Error('Didn\'t get the fs event!');
 								}
@@ -967,7 +967,7 @@ describe('FSWatcher', () => {
 					}
 
 					writeFile();
-				}, 100);
+				}, 150);
 			});
 
 			it('should recursively watch with two watchers; one with depth of 2', function (done) {
@@ -1032,7 +1032,7 @@ describe('FSWatcher', () => {
 
 					function checkEvent() {
 						try {
-							if (index < 2) {
+							if (index <= 2) {
 								if (!lastEvt) {
 									throw new Error('Didn\'t get the fs event!');
 								}
@@ -1067,7 +1067,7 @@ describe('FSWatcher', () => {
 					}
 
 					writeFile();
-				}, 100);
+				}, 150);
 			});
 
 			it('should recursively watch new subdirectories, then unwatch when deleted', function (done) {
@@ -1114,14 +1114,14 @@ describe('FSWatcher', () => {
 										} catch (e) {
 											done(e);
 										}
-									}, 100);
+									}, 150);
 								});
 							} catch (e) {
 								done(e);
 							}
 						}, 500);
 					}, 500);
-				}, 100);
+				}, 150);
 			});
 
 			it('should recursively watch new subdirectories with depth of 2, then unwatch when deleted', function (done) {
@@ -1166,14 +1166,14 @@ describe('FSWatcher', () => {
 										} catch (e) {
 											done(e);
 										}
-									}, 100);
+									}, 150);
 								});
 							} catch (e) {
 								done(e);
 							}
 						}, 500);
 					}, 500);
-				}, 100);
+				}, 150);
 			});
 		});
 
@@ -1229,7 +1229,7 @@ describe('FSWatcher', () => {
 					} catch (e) {
 						done(e);
 					}
-				}, 100);
+				}, 150);
 			});
 
 			it('should handle symlink to directory being deleted', function (done) {
@@ -1283,7 +1283,7 @@ describe('FSWatcher', () => {
 					} catch (e) {
 						done(e);
 					}
-				}, 100);
+				}, 150);
 			});
 
 			it('should handle if symlink to file is broken', function (done) {
@@ -1340,7 +1340,7 @@ describe('FSWatcher', () => {
 					} catch (e) {
 						done(e);
 					}
-				}, 100);
+				}, 150);
 			});
 
 			it('should handle symlink to file being deleted', function (done) {
@@ -1397,7 +1397,7 @@ describe('FSWatcher', () => {
 					} catch (e) {
 						done(e);
 					}
-				}, 100);
+				}, 150);
 			});
 
 			it('should handle if already broken absolute directory symlink', function (done) {
@@ -1442,7 +1442,7 @@ describe('FSWatcher', () => {
 						log(renderTree());
 						log('Recreating foo/bar directory: %s', highlight(barDir));
 						fs.mkdirsSync(barDir);
-					}, 100);
+					}, 150);
 				}, 500);
 			});
 
@@ -1490,7 +1490,7 @@ describe('FSWatcher', () => {
 						log(renderTree());
 						log('Recreating foo/bar directory: %s', highlight(barDir));
 						fs.mkdirsSync(barDir);
-					}, 100);
+					}, 150);
 				}, 500);
 			});
 		});
@@ -1523,7 +1523,7 @@ describe('FSWatcher', () => {
 				let counter = 0;
 
 				Promise.resolve()
-					.then(() => sleep(100))
+					.then(() => sleep(150))
 					.then(() => {
 						watcher = new FSWatcher(tmp, { recursive: true })
 							.on('change', evt => {
@@ -1538,7 +1538,7 @@ describe('FSWatcher', () => {
 								done(err);
 							});
 					})
-					.then(() => sleep(100))
+					.then(() => sleep(150))
 					.then(() => {
 						log(renderTree());
 						originalStatus = status();
@@ -1547,7 +1547,7 @@ describe('FSWatcher', () => {
 						log('Switching back to root user');
 						process.setuid(0);
 					})
-					.then(() => sleep(100))
+					.then(() => sleep(150))
 					.then(() => {
 						log('Creating bar dir: %s', highlight(barDir));
 						fs.mkdirsSync(barDir);
@@ -1557,7 +1557,7 @@ describe('FSWatcher', () => {
 
 						expect(counter).to.equal(0);
 					})
-					.then(() => sleep(100))
+					.then(() => sleep(150))
 					.then(() => {
 						log(renderTree());
 
@@ -1570,7 +1570,7 @@ describe('FSWatcher', () => {
 						log('Unrestricting %s', highlight(fooDir));
 						fs.chmodSync(fooDir, '755');
 					})
-					.then(() => sleep(100))
+					.then(() => sleep(150))
 					.then(() => {
 						const stats = status();
 						logStats(stats);
@@ -1587,7 +1587,7 @@ describe('FSWatcher', () => {
 						log('Writing baz file again: %s', highlight(bazFile));
 						fs.writeFileSync(bazFile, 'baz 2!');
 					})
-					.then(() => sleep(100))
+					.then(() => sleep(150))
 					.then(() => {
 						// now we have the event for baz.txt
 						expect(counter).to.equal(4);
@@ -1601,7 +1601,7 @@ describe('FSWatcher', () => {
 						log('Switching to effective user to %s', restricted.getUser());
 						process.seteuid(restricted.getUser());
 					})
-					.then(() => sleep(100))
+					.then(() => sleep(150))
 					.then(() => {
 						const stats = status();
 						logStats(stats);
@@ -1618,7 +1618,7 @@ describe('FSWatcher', () => {
 						log('Writing baz file yet again: %s', highlight(bazFile));
 						fs.writeFileSync(bazFile, 'baz 2!');
 					})
-					.then(() => sleep(100))
+					.then(() => sleep(150))
 					.then(() => {
 						// we should not have seen the last update to baz.txt
 						expect(counter).to.equal(5);
@@ -1649,7 +1649,7 @@ describe('FSWatcher', () => {
 						});
 
 					fs.writeFileSync(filename, 'foo!');
-				}, 100);
+				}, 150);
 			});
 
 			it('should emit error if file watch handler throws exception', done => {
@@ -1673,7 +1673,7 @@ describe('FSWatcher', () => {
 						});
 
 					fs.appendFileSync(filename, 'more foo!');
-				}, 100);
+				}, 150);
 			});
 		});
 	});

--- a/packages/appcd-gulp/src/templates/standard.js
+++ b/packages/appcd-gulp/src/templates/standard.js
@@ -238,10 +238,17 @@ module.exports = (opts) => {
 		log('Running: ' + ansiColors.cyan(execPath + ' ' + args.join(' ')));
 
 		// run!
-		if (spawnSync(execPath, args, { stdio: 'inherit' }).status) {
-			const err = new Error('At least one test failed :(');
-			err.showStack = false;
-			throw err;
+		try {
+			if (spawnSync(execPath, args, { stdio: 'inherit' }).status) {
+				const err = new Error('At least one test failed :(');
+				err.showStack = false;
+				throw err;
+			}
+		} finally {
+			const after = path.join(projectDir, 'test', 'after.js');
+			if (fs.existsSync(after)) {
+				require(after);
+			}
 		}
 	}
 

--- a/packages/appcd-machine-id/test/test-machine-id.js
+++ b/packages/appcd-machine-id/test/test-machine-id.js
@@ -7,6 +7,7 @@ import getMachineId from '../dist/machine-id';
 tmp.setGracefulCleanup();
 function makeTempDir() {
 	return tmp.dirSync({
+		mode: '755',
 		prefix: 'appcd-machine-id-test-',
 		unsafeCleanup: true
 	}).name;

--- a/packages/appcd-nodejs/test/test-nodejs.js
+++ b/packages/appcd-nodejs/test/test-nodejs.js
@@ -12,6 +12,7 @@ import {
 tmp.setGracefulCleanup();
 function makeTempDir() {
 	return tmp.dirSync({
+		mode: '755',
 		prefix: 'appcd-nodejs-test-',
 		unsafeCleanup: true
 	}).name;

--- a/packages/appcd-path/test/test-path.js
+++ b/packages/appcd-path/test/test-path.js
@@ -57,6 +57,7 @@ describe('path', () => {
 
 		it('should figure out the real path for a symlinked existing file', done => {
 			const tmpObj = tmp.dirSync({
+				mode: '755',
 				prefix: 'appcd-path-test-'
 			});
 			const dir = _path.join(tmpObj.name, 'bar');
@@ -79,6 +80,7 @@ describe('path', () => {
 
 		it('should figure out the real path for a non-symlinked non-existent file', done => {
 			const tmpObj = tmp.dirSync({
+				mode: '755',
 				prefix: 'appcd-path-test-'
 			});
 			const filename = _path.join(tmpObj.name, 'foo.txt');

--- a/packages/appcd-plugin/test/test-plugin-manager.js
+++ b/packages/appcd-plugin/test/test-plugin-manager.js
@@ -694,8 +694,8 @@ describe('PluginManager', () => {
 		});
 
 		it('should call a service that calls a service in another plugin', function (done) {
-			this.timeout(10000);
-			this.slow(9000);
+			this.timeout(20000);
+			this.slow(19000);
 
 			const pluginDir = path.join(__dirname, 'fixtures', 'xdep');
 

--- a/packages/appcd-plugin/test/test-plugin-manager.js
+++ b/packages/appcd-plugin/test/test-plugin-manager.js
@@ -17,6 +17,7 @@ const { log } = appcdLogger('test:appcd:plugin:manager');
 const { highlight } = appcdLogger.styles;
 
 const tmpDir = tmp.dirSync({
+	mode: '755',
 	prefix: 'appcd-plugin-test-',
 	unsafeCleanup: true
 }).name;

--- a/packages/appcd-plugin/test/test-plugin-path.js
+++ b/packages/appcd-plugin/test/test-plugin-path.js
@@ -19,6 +19,7 @@ const { log } = appcdLogger('test:appcd:plugin-path');
 const { highlight, magenta } = appcdLogger.styles;
 
 const _tmpDir = tmp.dirSync({
+	mode: '755',
 	prefix: 'appcd-plugin-test-',
 	unsafeCleanup: true
 }).name;

--- a/packages/appcd-subprocess/test/test-subprocess-manager.js
+++ b/packages/appcd-subprocess/test/test-subprocess-manager.js
@@ -280,7 +280,10 @@ describe('SubprocessManager', () => {
 	});
 
 	describe('ipc', () => {
-		it('should spawn a command with ipc', done => {
+		it('should spawn a command with ipc', function (done) {
+			this.timeout(10000);
+			this.slow(9000);
+
 			const subprocessMgr = new SubprocessManager();
 			subprocessMgr
 				.call('/spawn', {

--- a/packages/appcd-subprocess/test/test-subprocess-manager.js
+++ b/packages/appcd-subprocess/test/test-subprocess-manager.js
@@ -10,6 +10,7 @@ const logger = appcdLogger('test:appcd:subprocess');
 tmp.setGracefulCleanup();
 function makeTempDir() {
 	return tmp.dirSync({
+		mode: '755',
 		prefix: 'appcd-subprocess-test-',
 		unsafeCleanup: true
 	}).name;

--- a/packages/appcd-telemetry/test/test-telemetry.js
+++ b/packages/appcd-telemetry/test/test-telemetry.js
@@ -13,6 +13,7 @@ import { sleep } from 'appcd-util';
 const { log } = appcdLogger('test:appcd:telemetry');
 
 const tmpDir = tmp.dirSync({
+	mode: '755',
 	prefix: 'appcd-telemetry-test-',
 	unsafeCleanup: true
 }).name;


### PR DESCRIPTION
[DAEMON-235] Greatly improved recursion support. Deleted directories now remove recursive children unless they are explicitly being watched. Supports recursively watching directories that were created after the fs watcher was created. Fixed bug were files were being recursively watched instead of just directories.

[DAEMON-233] Added support for permission checks. If a node is restricted, it will not be able to descend the directory tree.

Improved fs watcher code quality and docs. Unit tests are now at 98.34% on macOS.

To test, you must run `gulp coverage` on all platforms, then `sudo gulp coverage` on Linux and macOS.