### PR TITLE
appcd-gulp: Fixed bug where the main entry point was still referencin…

### DIFF
--- a/packages/appcd-gulp/CHANGELOG.md
+++ b/packages/appcd-gulp/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.2 (April 9, 2018)
+
+ * Fixed bug where the main entry point was still referencing `pretty-log` instead of `fancy-log`.
+
 # v1.1.1 (April 9, 2018)
 
  * Added support for running `test/after.js` after tests have run regardless of success.

--- a/packages/appcd-gulp/package.json
+++ b/packages/appcd-gulp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-gulp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Common gulp tasks and utilities.",
   "main": "./src/index",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",

--- a/packages/appcd-gulp/src/index.js
+++ b/packages/appcd-gulp/src/index.js
@@ -10,8 +10,9 @@
  * @param {String} [opts.template] - The name of the template to use.
  */
 module.exports = opts => {
+	const ansiColors  = require('ansi-colors');
 	const fs = require('fs');
-	const log = require('pretty-log');
+	const log = require('fancy-log');
 	const path = require('path');
 
 	let parent = module.parent;
@@ -26,12 +27,12 @@ module.exports = opts => {
 	}
 
 	if (!opts.projectDir) {
-		log(colors.red('You MUST call appcd-gulp from a gulpfile.js'));
+		log(ansiColors.red('You MUST call appcd-gulp from a gulpfile.js'));
 		process.exit(1);
 	}
 
 	if (!opts.template) {
-		log(colors.red('You MUST specify a template'));
+		log(ansiColors.red('You MUST specify a template'));
 		process.exit(1);
 	}
 
@@ -41,7 +42,7 @@ module.exports = opts => {
 			throw new Error();
 		}
 	} catch (e) {
-		log(colors.red(opts.template ? `Unknown template: ${opts.template}` : 'Invalid template'));
+		log(ansiColors.red(opts.template ? `Unknown template: ${opts.template}` : 'Invalid template'));
 		process.exit(1);
 	}
 


### PR DESCRIPTION
appcd-gulp: Fixed bug where the main entry point was still referencing 'pretty-log' instead of 'fancy-log'.