### PR TITLE
appcd-plugin@1.1.1

### DIFF
--- a/docs/Services/plugin.md
+++ b/docs/Services/plugin.md
@@ -4,7 +4,8 @@
 
 Exposes the Plugin Manager.
 
-Accessing the service returns the Plugin Manager status.
+Accessing the service returns the Plugin Manager status including the plugin paths and all plugins
+found and registered in those paths.
 
 ```javascript
 Dispatcher
@@ -58,13 +59,13 @@ Dispatcher
 $ appcd exec /appcd/plugin/unregister '{"path":"/path/to/directory"}'
 ```
 
-### `/appcd/stop`
+### `/appcd/plugin/stop`
 
 Stops all versions of all plugins associated with the specified plugin path.
 
 ```javascript
 Dispatcher
-    .call('/appcd/stop', {
+    .call('/appcd/plugin/stop', {
         path: '/path/to/directory'
     })
     .then(result => {
@@ -77,13 +78,13 @@ Dispatcher
 $ appcd exec /appcd/plugin/stop '{"path":"/path/to/directory"}'
 ```
 
-### `/appcd/stop/<PLUGIN_NAME>`
+### `/appcd/plugin/stop/<PLUGIN_NAME>`
 
 Stops all versions of the specified plugin name.
 
 ```javascript
 Dispatcher
-    .call('/appcd/stop/foo')
+    .call('/appcd/plugin/stop/foo')
     .then(result => {
 		// 200 OK
         console.log(result);
@@ -94,13 +95,13 @@ Dispatcher
 $ appcd exec /appcd/plugin/stop/foo
 ```
 
-### `/appcd/stop/<PLUGIN_NAME>/<VERSION>`
+### `/appcd/plugin/stop/<PLUGIN_NAME>/<VERSION>`
 
 Stops a specific version or version range for the specified plugin name.
 
 ```javascript
 Dispatcher
-    .call('/appcd/stop/foo/1.0.0')
+    .call('/appcd/plugin/stop/foo/1.0.0')
     .then(result => {
 		// 200 OK
         console.log(result);
@@ -113,7 +114,7 @@ $ appcd exec /appcd/plugin/stop/foo/1.0.0
 
 ```javascript
 Dispatcher
-    .call('/appcd/stop/foo/2.x')
+    .call('/appcd/plugin/stop/foo/2.x')
     .then(result => {
 		// 200 OK
         console.log(result);
@@ -122,4 +123,61 @@ Dispatcher
 
 ```bash
 $ appcd exec /appcd/plugin/stop/foo/2.x
+```
+
+### `/appcd/plugin/status`
+
+Returns the status of all registered plugins.
+
+```javascript
+Dispatcher
+    .call('/appcd/plugin/status')
+    .then(result => {
+		// 200 OK
+        console.log(result);
+    });
+```
+
+```bash
+$ appcd exec /appcd/plugin/status
+```
+
+To get a single plugin's status by path:
+
+```bash
+$ appcd exec /appcd/plugin/status '{"path":"/path/to/directory"}'
+```
+
+### `/appcd/plugin/status/<PLUGIN_NAME>`
+
+Gets the status for all plugins matching the specified name.
+
+```javascript
+Dispatcher
+    .call('/appcd/plugin/status/appcd-plugin-titanium-sdk')
+    .then(result => {
+		// 200 OK
+        console.log(result);
+    });
+```
+
+```bash
+$ appcd exec /appcd/plugin/status/appcd-plugin-titanium-sdk
+```
+
+### `/appcd/status/<PLUGIN_NAME>/<VERSION>`
+
+Gets the status for all plugins matching the specified name and version range.
+
+```javascript
+Dispatcher
+    .call('/appcd/plugin/status/appcd-plugin-titanium-sdk/1.x')
+    .then(result => {
+		// 200 OK
+        console.log(result);
+    });
+```
+
+```bash
+$ appcd exec /appcd/plugin/status/appcd-plugin-titanium-sdk/1.x
 ```

--- a/packages/appcd-plugin/CHANGELOG.md
+++ b/packages/appcd-plugin/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.1.1 (Apr 11, 2018)
+
+ * Reset the plugin's `stack` message when the plugin is stopped.
+ * Fixed error handling when a plugin fails to activate or deactivate.
+ * Added `/appcd/plugin/status/:name?/:version?` service to get a plugin's status without invoking
+   the plugin.
+
 # v1.1.0 (Apr 9, 2018)
 
  * Enforce appcd version compatible check when loading a plugin.

--- a/packages/appcd-plugin/package.json
+++ b/packages/appcd-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Library for loading and executing plugins.",
   "main": "./dist/index",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",

--- a/packages/appcd-plugin/src/external-plugin.js
+++ b/packages/appcd-plugin/src/external-plugin.js
@@ -129,9 +129,9 @@ export default class ExternalPlugin extends PluginBase {
 	 * @returns {Promise}
 	 * @access private
 	 */
-	async onStop() {
+	onStop() {
 		// send deactivate message which will trigger the child to exit gracefully
-		await this.tunnel.send({ type: 'deactivate' });
+		return this.tunnel.send({ type: 'deactivate' });
 	}
 
 	/**
@@ -208,6 +208,10 @@ export default class ExternalPlugin extends PluginBase {
 					})
 					.then(() => {
 						send(new Response(codes.OK));
+						process.exit(0);
+					})
+					.catch(err => {
+						send(err);
 						process.exit(0);
 					});
 			}
@@ -396,6 +400,7 @@ export default class ExternalPlugin extends PluginBase {
 									// reset the plugin error state
 									this.appcdLogger.log('Reseting error state');
 									this.info.error = null;
+									this.info.stack = null;
 								})
 								.catch(err => {
 									this.appcdLogger.error('Failed to restart %s plugin: %s', highlight(this.plugin.toString()), err);

--- a/packages/appcd-plugin/src/plugin-base.js
+++ b/packages/appcd-plugin/src/plugin-base.js
@@ -238,8 +238,14 @@ export default class PluginBase extends EventEmitter {
 			this.setState(states.STOPPING);
 		}
 
-		await this.onStop();
-		this.deactivate();
+		try {
+			await this.onStop();
+		} catch (e) {
+			this.info.error = e.message;
+			this.info.stack = e.stack;
+		} finally {
+			this.deactivate();
+		}
 	}
 
 	/**

--- a/packages/appcd-plugin/src/plugin.js
+++ b/packages/appcd-plugin/src/plugin.js
@@ -320,6 +320,7 @@ export default class Plugin extends EventEmitter {
 		}
 
 		this.error = null;
+		this.stack = null;
 
 		return this.impl.start();
 	}


### PR DESCRIPTION
Reset the plugin's 'stack' message when the plugin is stopped.

Fixed error handling when a plugin fails to activate or deactivate.

Added '/appcd/plugin/status/:name?/:version?' service to get a plugin's status without invoking the plugin.

Updated the plugin service docs with the status endpoint and fixed some typos.