### PR TITLE
appcd-gulp fixes for amplify-auth-library

### DIFF
--- a/packages/appcd-gulp/src/templates/standard.js
+++ b/packages/appcd-gulp/src/templates/standard.js
@@ -166,10 +166,11 @@ module.exports = (opts) => {
 
 		// add nyc
 		if (cover) {
+			const nycModuleBinDir = resolveModuleBin('nyc');
 			if (isWindows) {
-				execPath = path.join(appcdGulpNodeModulesPath, '.bin', 'nyc.cmd');
+				execPath = path.join(nycModuleBinDir, 'nyc.cmd');
 			} else {
-				args.push(path.join(appcdGulpNodeModulesPath, '.bin', 'nyc'));
+				args.push(path.join(nycModuleBinDir, 'nyc'));
 			}
 
 			args.push(
@@ -193,12 +194,12 @@ module.exports = (opts) => {
 		}
 
 		// add mocha
-		const mocha = resolveModule('mocha');
+		const mocha = resolveModuleBin('mocha');
 		if (!mocha) {
 			log('Unable to find mocha!');
 			process.exit(1);
 		}
-		args.push(path.join(mocha, 'bin', 'mocha'));
+		args.push(path.join(mocha, 'mocha'));
 
 		// add --inspect
 		if (process.argv.indexOf('--inspect') !== -1 || process.argv.indexOf('--inspect-brk') !== -1) {
@@ -263,6 +264,10 @@ module.exports = (opts) => {
 			console.log('File ' + event.path + ' was ' + event.type + ', running tasks...');
 		});
 	});
+
+	function resolveModuleBin(name) {
+		return path.resolve(resolveModule(name), '..', '.bin');
+	}
 
 	function resolveModule(name) {
 		let dir = path.join(appcdGulpNodeModulesPath, name);

--- a/packages/appcd-gulp/src/test-transpile.js
+++ b/packages/appcd-gulp/src/test-transpile.js
@@ -77,7 +77,7 @@ if (process.env.APPCD_COVERAGE) {
 	const distGRegExp = /([/\\])dist([/\\])/g;
 
 	Module._resolveFilename = function (request, parent, isMain) {
-		if (distRegExp.test(request) && parent && (parent.id.startsWith(cwd) || parent.id.startsWith(realcwd))) {
+		if (distRegExp.test(request) && parent && (parent.id.startsWith(cwd) || parent.id.startsWith(realcwd)) && !parent.id.includes('node_modules')) {
 			request = request.replace(distGRegExp, (m, q1, q2) => `${q1}src${q2}`);
 		}
 		return originalResolveFilename(request, parent, isMain);


### PR DESCRIPTION
This solves the following problems I encountered while running `gulp coverage` on amplify-auth-library

- Unable to find nyc bin `Error: Cannot find module '/Users/eharris/Documents/git/amplify/amplify-auth-library/node_modules/appcd-gulp/node_modules/.bin/nyc'`
	- I think this is because npm was hoisting nyc out of appcd-gulp so the hard coded path would fail, s require.resolve finds the right place for us and then it's much easier to work backwards

- `Error: Cannot find module './src/base64url'`
	- In test-transpile it looks to be doing anything that is in a folder named `dist`, so it was trying to transpile `Users/eharris/Documents/git/amplify/amplify-auth-library/node_modules/base64url/index.js` which it doesn't have the `src` folder for, so we go boom.

Tested both of these changes against the full suite of appc-daemon tests and my coverage stats exactly match the last Jenkins run