### PR TITLE
appcd@1.1.2 and appcd-core@1.1.2 updated deps.

### DIFF
--- a/packages/appcd-core/CHANGELOG.md
+++ b/packages/appcd-core/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.1.2 (May 17, 2018)
+
+ * Updated dependencies:
+   - appcd-gulp 1.1.1 -> 1.1.4
+   - cli-kit 0.0.12 -> 0.1.2
+   - fs-extra 5.0.0 -> 6.0.1
+
 # v1.1.1 (Apr 11, 2018)
 
  * Ensure that all WebSocket responses have a status and a (string) statusCode.

--- a/packages/appcd-core/package.json
+++ b/packages/appcd-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Appc Daemon server implementation.",
   "main": "./dist/main",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",
@@ -34,14 +34,14 @@
     "appcd-subprocess": "^1.1.0",
     "appcd-telemetry": "^1.1.0",
     "appcd-util": "^1.1.0",
-    "cli-kit": "^0.1.1",
+    "cli-kit": "^0.1.2",
     "fs-extra": "^6.0.1",
     "gawk": "^4.4.5",
     "global-modules": "^1.0.0",
     "msgpack-lite": "^0.1.26"
   },
   "devDependencies": {
-    "appcd-gulp": "^1.1.3",
+    "appcd-gulp": "^1.1.4",
     "gulp": "^3.9.1"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon#readme",

--- a/packages/appcd-gulp/CHANGELOG.md
+++ b/packages/appcd-gulp/CHANGELOG.md
@@ -1,7 +1,26 @@
+# v1.1.4 (May 17, 2018)
+
+ * Fixed regression with resolving mocha on Windows.
+ * Module filename resolver now resolves parent id before testing if file is a dist file. This is a
+   precautionary measure.
+ * Updated sinon sandbox creation to avoid deprecated API.
+ * Updated dependencies:
+   - ansi-colors 1.1.0 -> 2.0.1
+   - babel-eslint 8.2.2 -> 8.2.3
+   - babel-preset-minify 0.4.0 -> 0.4.3
+   - core-js 2.5.5 -> 2.5.6
+   - esdoc 1.0.4 -> 1.1.0
+   - esling-config-axway 2.0.10 -> 2.0.14
+   - mocha 5.0.5 -> 5.1.1
+   - nyc 11.6.0 -> 11.8.0
+   - sinon 4.5.0 -> 5.0.7
+
 # v1.1.3 (May 4, 2018)
 
- * Fixed bug resolving nyc binary when it existed in `node_modules/.bin` rather than `node_modules/appcd-gulp/.bin`.
- * Fixed bug where when running `gulp coverage` dist folders under node_modules would attempt to be transpiled incorrectly.
+ * Fixed bug resolving nyc binary when it existed in `node_modules/.bin` rather than
+   `node_modules/appcd-gulp/.bin`.
+ * Fixed bug where when running `gulp coverage` dist folders under node_modules would attempt to be
+   transpiled incorrectly.
 
 # v1.1.2 (Apr 9, 2018)
 

--- a/packages/appcd-gulp/package.json
+++ b/packages/appcd-gulp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-gulp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Common gulp tasks and utilities.",
   "main": "./src/index",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",

--- a/packages/appcd-gulp/src/test-setup.js
+++ b/packages/appcd-gulp/src/test-setup.js
@@ -5,7 +5,7 @@ global.expect = global.chai.expect;
 global.sinon = require('sinon');
 
 beforeEach(function () {
-	this.sandbox = global.sinon.sandbox.create();
+	this.sandbox = global.sinon.createSandbox();
 	global.spy = this.sandbox.spy.bind(this.sandbox);
 	global.stub = this.sandbox.stub.bind(this.sandbox);
 });

--- a/packages/appcd-gulp/src/test-transpile.js
+++ b/packages/appcd-gulp/src/test-transpile.js
@@ -77,7 +77,8 @@ if (process.env.APPCD_COVERAGE) {
 	const distGRegExp = /([/\\])dist([/\\])/g;
 
 	Module._resolveFilename = function (request, parent, isMain) {
-		if (distRegExp.test(request) && parent && (parent.id.startsWith(cwd) || parent.id.startsWith(realcwd)) && !parent.id.includes('node_modules')) {
+		const parentId = parent && path.resolve(parent.id);
+		if (distRegExp.test(request) && parentId && (parentId.startsWith(cwd) || parentId.startsWith(realcwd)) && !parentId.includes('node_modules')) {
 			request = request.replace(distGRegExp, (m, q1, q2) => `${q1}src${q2}`);
 		}
 		return originalResolveFilename(request, parent, isMain);

--- a/packages/appcd/CHANGELOG.md
+++ b/packages/appcd/CHANGELOG.md
@@ -1,7 +1,11 @@
-# Unreleased
+# v1.1.2 (May 17, 2018)
 
  * Exported the CLI definition so that `appcd` can extend `cli-kit` enabled CLI's.
    [(DAEMON-256)](https://jira.appcelerator.org/browse/DAEMON-256)
+ * Updated dependencies:
+   - appcd-gulp 1.1.1 -> 1.1.4
+   - cli-kit 0.0.12 -> 0.1.2
+   - source-map-support 0.5.4 -> 0.5.6
 
 # v1.1.1 (Apr 10, 2018)
 

--- a/packages/appcd/package.json
+++ b/packages/appcd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A daemon that powers Appcelerator tooling and makes the impossible possible.",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",
   "maintainers": [
@@ -35,12 +35,12 @@
     "appcd-nodejs": "^1.1.0",
     "appcd-path": "^1.1.0",
     "appcd-util": "^1.1.0",
-    "cli-kit": "^0.1.1",
+    "cli-kit": "^0.1.2",
     "cli-table2": "^0.2.0",
     "source-map-support": "^0.5.6"
   },
   "devDependencies": {
-    "appcd-gulp": "^1.1.3",
+    "appcd-gulp": "^1.1.4",
     "gulp": "^3.9.1"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,13 +247,13 @@
 
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
-  resolved "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
   dependencies:
     samsam "1.3.0"
 
 "@types/node@*":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.0.tgz#2783ee1b6c47cbd4044f4a233976c1ac5fa9e942"
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.1.tgz#ca39d8607fa1fcb146b0530420b93f1dd4802f6c"
 
 JSONStream@^1.0.4, JSONStream@^1.3.2:
   version "1.3.2"
@@ -379,7 +379,7 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
-ansi-colors@^1.0.1, ansi-colors@^1.1.0:
+ansi-colors@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.1.0.tgz#6374b4dd5d4718ff3ce27a671a3b1cad077132a9"
   dependencies:
@@ -461,48 +461,6 @@ appcd-dump-viewer@^1.1.4:
     sprintf "^0.1.5"
     vue "^2.5.13"
     vuetify "^1.0.0"
-
-appcd-gulp@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/appcd-gulp/-/appcd-gulp-1.1.3.tgz#4f294d136aad0443500f9134d6fde8c66ebde687"
-  dependencies:
-    "@babel/core" latest
-    "@babel/plugin-transform-async-to-generator" latest
-    "@babel/polyfill" latest
-    "@babel/register" latest
-    ansi-colors "^1.1.0"
-    babel-eslint "^8.2.2"
-    babel-plugin-dynamic-import-node "^1.2.0"
-    babel-plugin-istanbul "^4.1.6"
-    babel-plugin-transform-class-properties next
-    babel-plugin-transform-decorators-legacy "^1.3.4"
-    babel-plugin-transform-es2015-destructuring next
-    babel-plugin-transform-es2015-modules-commonjs next
-    babel-plugin-transform-es2015-parameters next
-    babel-plugin-transform-object-rest-spread next
-    babel-preset-minify "^0.4.0"
-    chai "^4.1.2"
-    chai-as-promised "^7.1.1"
-    core-js "^2.5.5"
-    del "^3.0.0"
-    esdoc "^1.0.4"
-    esdoc-ecmascript-proposal-plugin "^1.0.0"
-    esdoc-standard-plugin "^1.0.0"
-    eslint "^4.19.1"
-    eslint-config-axway "^2.0.10"
-    eslint-plugin-mocha "^5.0.0"
-    fancy-log "^1.3.2"
-    gulp-babel next
-    gulp-chug "^0.5.1"
-    gulp-debug "^3.2.0"
-    gulp-eslint "^4.0.2"
-    gulp-load-plugins "^1.5.0"
-    gulp-plumber "^1.2.0"
-    mocha "^5.0.5"
-    mocha-jenkins-reporter "^0.3.12"
-    nyc "^11.6.0"
-    sinon "^4.5.0"
-    sinon-chai "^3.0.0"
 
 appcd-plugin-android@^1.1.0:
   version "1.1.0"
@@ -749,7 +707,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-eslint@^8.2.2, babel-eslint@^8.2.3:
+babel-eslint@^8.2.3:
   version "8.2.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.3.tgz#1a2e6681cc9bc4473c32899e59915e19cd6733cf"
   dependencies:
@@ -1103,7 +1061,7 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
 
-babel-preset-minify@^0.4.0, babel-preset-minify@^0.4.3:
+babel-preset-minify@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/babel-preset-minify/-/babel-preset-minify-0.4.3.tgz#b29c3dd6918905384598f092b955152e26a1fe0f"
   dependencies:
@@ -1679,9 +1637,9 @@ cli-kit@^0.0.12:
     snooplogg "^1.9.2"
     source-map-support "^0.5.3"
 
-cli-kit@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/cli-kit/-/cli-kit-0.1.1.tgz#8f42dd7a47d9f33a447cca7fa766990632683621"
+cli-kit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-kit/-/cli-kit-0.1.2.tgz#9586e65a80876d61d9219d36cd07d73acb718856"
   dependencies:
     hook-emitter "^2.1.0"
     isexe "^2.0.0"
@@ -2096,7 +2054,7 @@ copy-to@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/copy-to/-/copy-to-2.0.1.tgz#2680fbb8068a48d08656b6098092bdafc906f4a5"
 
-core-js@^2.4.0, core-js@^2.5.3, core-js@^2.5.5, core-js@^2.5.6:
+core-js@^2.4.0, core-js@^2.5.3, core-js@^2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
 
@@ -2671,7 +2629,7 @@ esdoc-unexported-identifier-plugin@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/esdoc-unexported-identifier-plugin/-/esdoc-unexported-identifier-plugin-1.0.0.tgz#1f9874c6a7c2bebf9ad397c3ceb75c9c69dabab1"
 
-esdoc@^1.0.4, esdoc@^1.1.0:
+esdoc@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/esdoc/-/esdoc-1.1.0.tgz#07d40ebf791764cd537929c29111e20a857624f3"
   dependencies:
@@ -2687,7 +2645,7 @@ esdoc@^1.0.4, esdoc@^1.1.0:
     minimist "1.2.0"
     taffydb "2.7.3"
 
-eslint-config-axway@^2.0.10, eslint-config-axway@^2.0.14:
+eslint-config-axway@^2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/eslint-config-axway/-/eslint-config-axway-2.0.14.tgz#31c0b17765c7c5558ad848cdd506c7dd42c348c1"
   dependencies:
@@ -2711,8 +2669,8 @@ eslint-module-utils@^2.2.0:
     pkg-dir "^1.0.0"
 
 eslint-plugin-import@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.11.0.tgz#15aeea37a67499d848e8e981806d4627b5503816"
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
   dependencies:
     contains-path "^0.1.0"
     debug "^2.6.8"
@@ -2910,9 +2868,9 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect-ct@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/expect-ct/-/expect-ct-0.1.0.tgz#52735678de18530890d8d7b95f0ac63640958094"
+expect-ct@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/expect-ct/-/expect-ct-0.1.1.tgz#de84476a2dbcb85000d5903737e9bc8a5ba7b897"
 
 extend-shallow@^1.1.2:
   version "1.1.4"
@@ -3894,12 +3852,12 @@ helmet-csp@2.7.0:
     platform "1.3.5"
 
 helmet@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.12.0.tgz#2098e35cf4e51c64c2f1d38670b7d382a377d92c"
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.12.1.tgz#8b05bbd60f3966d70f13dad0de2c1d6c1a8303f1"
   dependencies:
     dns-prefetch-control "0.1.0"
     dont-sniff-mimetype "1.0.0"
-    expect-ct "0.1.0"
+    expect-ct "0.1.1"
     frameguard "3.0.0"
     helmet-csp "2.7.0"
     hide-powered-by "1.0.0"
@@ -5234,8 +5192,8 @@ lodash@~1.0.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
 
 lolex@^2.2.0, lolex@^2.3.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.5.0.tgz#69d6a667607738564daf108f63240ae8cbd28fb4"
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.6.0.tgz#cf9166f3c9dece3cdeb5d6b01fce50f14a1203e3"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -5522,7 +5480,7 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.2.1, minipass@^2.2.4:
+minipass@^2.2.1, minipass@^2.2.4, minipass@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.0.tgz#2e11b1c46df7fe7f1afbe9a490280add21ffe384"
   dependencies:
@@ -5619,7 +5577,7 @@ mocha@^3.0.0:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-mocha@^5.0.5, mocha@^5.1.1:
+mocha@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.1.1.tgz#b774c75609dac05eb48f4d9ba1d827b97fde8a7b"
   dependencies:
@@ -5862,8 +5820,8 @@ normalize-path@^2.0.1:
     remove-trailing-separator "^1.0.1"
 
 npm-audit-report@^1.0.8:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/npm-audit-report/-/npm-audit-report-1.1.0.tgz#c4c74bb08b3be25cafaff89fd68ed81fecf6846d"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/npm-audit-report/-/npm-audit-report-1.2.1.tgz#14813e9551f0f33088e7acc442e83ea6d627ef13"
   dependencies:
     cli-table2 "^0.2.0"
     console-control-strings "^1.1.0"
@@ -5883,8 +5841,8 @@ npm-install-checks@~3.0.0:
     semver "^2.3.0 || 3.x || 4 || 5"
 
 npm-lifecycle@^2.0.0, npm-lifecycle@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-2.0.1.tgz#897313f05ed24db8e28d99fa8b42c31b625e6237"
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-2.0.3.tgz#696bedf1143371163e9cc16fe872357e25d8d90e"
   dependencies:
     byline "^5.0.0"
     graceful-fs "^4.1.11"
@@ -6130,7 +6088,7 @@ number-is-nan@^1.0.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
 
-nyc@^11.6.0, nyc@^11.8.0:
+nyc@^11.8.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.8.0.tgz#1e8453b0644f8fea4d829b1a6636663157cd3b00"
   dependencies:
@@ -6371,8 +6329,8 @@ pacote@^7.5.1:
     which "^1.3.0"
 
 pacote@^8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/pacote/-/pacote-8.1.1.tgz#7ee85dad2bccf5524e5460508f833c60dddf5183"
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-8.1.2.tgz#7e4f5e8129597bdfd3e1921d4cbb1bc5e55db021"
   dependencies:
     bluebird "^3.5.1"
     cacache "^11.0.1"
@@ -6381,6 +6339,7 @@ pacote@^8.1.1:
     lru-cache "^4.1.2"
     make-fetch-happen "^4.0.1"
     minimatch "^3.0.4"
+    minipass "^2.3.0"
     mississippi "^3.0.0"
     mkdirp "^0.5.1"
     normalize-package-data "^2.4.0"
@@ -6744,8 +6703,8 @@ pump@^3.0.0:
     once "^1.3.1"
 
 pumpify@^1.3.3:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.0.tgz#30c905a26c88fa0074927af07256672b474b1c15"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
   dependencies:
     duplexify "^3.6.0"
     inherits "^2.0.3"
@@ -7354,18 +7313,6 @@ sinon-chai@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.0.0.tgz#d5cbd70fa71031edd96b528e0eed4038fcc99f29"
 
-sinon@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.5.0.tgz#427ae312a337d3c516804ce2754e8c0d5028cb04"
-  dependencies:
-    "@sinonjs/formatio" "^2.0.0"
-    diff "^3.1.0"
-    lodash.get "^4.4.2"
-    lolex "^2.2.0"
-    nise "^1.2.0"
-    supports-color "^5.1.0"
-    type-detect "^4.0.5"
-
 sinon@^5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.0.7.tgz#3bded6a73613ccc9e512e20246ced69a27c27dab"
@@ -7740,8 +7687,8 @@ stringify-object@^3.0.0:
     is-regexp "^1.0.0"
 
 stringstream@~0.0.4:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
appcd@1.1.2 and appcd-core@1.1.2 updated deps.

appcd-gulp@1.1.4 fixed deprecated sinon api and resolve parent id in transpile filename resolver.