### PR TITLE
fix(appcd-util): Fixed support for Node.js 11.

### DIFF
--- a/packages/appcd-core/CHANGELOG.md
+++ b/packages/appcd-core/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.1
+
+ * Removed `getActiveHandles()` call which no longer works in Node.js 11 and switched to
+   `trackTimers()` which uses async hooks and works with Node.js 8.1.0 or newer.
+   [(DAEMON-268)](https://jira.appcelerator.org/browse/DAEMON-268)
+
 # v2.0.0 (Nov 27, 2018)
 
  * Bumped minimum Node.js version from 8.0.0 to 8.10.0.

--- a/packages/appcd-util/CHANGELOG.md
+++ b/packages/appcd-util/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.1.5
+
+ * Updated `getActiveHandles()` to gracefully work in the event Node.js deprecates
+   `process._getActiveHandles()`.
+ * Gracefully handle calls to `process.binding()` should Node.js deprecate it or any of the
+   requested bindings.
+ * Added `trackTimers()` function in lieu of `getActiveHandles()` no longer being reliable for
+   determining active timers in Node.js 11. `trackTimers()` uses async hooks which where added in
+   Node.js 8.1.0.
+   [(DAEMON-268)](https://jira.appcelerator.org/browse/DAEMON-268)
+ * `tailgate()` no longer forces asynchronous execution of the callback using `setImmediate()`.
+
 # v1.1.4 (Nov 26, 2018)
 
  * Updated dependencies.

--- a/packages/appcd-util/test/test-util.js
+++ b/packages/appcd-util/test/test-util.js
@@ -433,7 +433,6 @@ describe('util', () => {
 		it('should return the active handles', done => {
 			const handles = util.getActiveHandles();
 			expect(handles).to.be.an.instanceof(Object);
-			expect(handles.timers).to.have.length.above(0);
 			done();
 		});
 	});
@@ -821,6 +820,43 @@ describe('util', () => {
 					expect(err.message).to.equal('oh snap');
 					done();
 				});
+		});
+	});
+
+	describe('trackTimers()', () => {
+		it('should track there were no timers', () => {
+			const timers = [];
+			try {
+				const stop = util.trackTimers();
+				const activeTimers = stop();
+				expect(activeTimers).to.have.lengthOf(timers.length);
+			} finally {
+				timers.forEach(clearTimeout);
+			}
+		});
+
+		it('should track a single setTimeout()', () => {
+			const timers = [];
+			try {
+				const stop = util.trackTimers();
+				timers.push(setTimeout(() => {}, 1e7));
+				const activeTimers = stop();
+				expect(activeTimers).to.have.lengthOf(timers.length);
+			} finally {
+				timers.forEach(a => clearTimeout(a));
+			}
+		});
+
+		it('should track a multiple setTimeout()\'s', () => {
+			const timers = [];
+			try {
+				const stop = util.trackTimers();
+				timers.push(setTimeout(() => {}, 1e7));
+				const activeTimers = stop();
+				expect(activeTimers).to.have.lengthOf(timers.length);
+			} finally {
+				timers.forEach(clearTimeout);
+			}
 		});
 	});
 


### PR DESCRIPTION
Futureproofed use of process._getActiveHandles() and process.binding().

Replaced dependency on timer_wrap.

Added new trackTimers() function that uses async hooks.

Fixes DAEMON-268.

https://jira.appcelerator.org/browse/DAEMON-268