### PR TITLE
chore(appcd-gulp): Added cobertura reporter when running nyc.

### DIFF
--- a/packages/appcd-gulp/CHANGELOG.md
+++ b/packages/appcd-gulp/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.0.1 (Mar 6, 2019)
+
+ * Added cobertura reporter when running nyc.
+
 # v2.0.0 (Jan 16, 2019)
 
  * Upgraded to Gulp 4.

--- a/packages/appcd-gulp/package.json
+++ b/packages/appcd-gulp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-gulp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Common gulp tasks and utilities.",
   "main": "./src/index",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",

--- a/packages/appcd-gulp/src/templates/standard.js
+++ b/packages/appcd-gulp/src/templates/standard.js
@@ -155,6 +155,7 @@ module.exports = (opts) => {
 				'--reporter=json',
 				'--reporter=text',
 				'--reporter=text-summary',
+				'--reporter=cobertura',
 				'--require', path.resolve(__dirname, '../test-transpile.js'),
 				'--show-process-tree',
 				process.execPath // need to specify node here so that spawn-wrap works


### PR DESCRIPTION
chore(appcd-gulp): v2.0.1