### PR TITLE
[DAEMON-273] fix(appcd-plugin): Fixed plugin IPC tunnel to send the 'headers' and …

### DIFF
--- a/packages/appcd-client/src/client.js
+++ b/packages/appcd-client/src/client.js
@@ -287,7 +287,7 @@ export default class Client {
 		// be wired up
 		setImmediate(() => {
 			this.connect()
-				.on('connected', client => {
+				.once('connected', client => {
 					this.requests[id] = response => {
 						const status = response.status = ~~response.status || 500;
 						const statusClass = Math.floor(status / 100);
@@ -296,7 +296,9 @@ export default class Client {
 						// no need for the id anymore
 						delete response.id;
 
-						log(`${style(status)} ${highlight(req.path)} ${note(`${new Date() - startTime}ms`)}`);
+						if (response.fin) {
+							log(`${style(status)} ${highlight(req.path)} ${note(`${new Date() - startTime}ms`)}`);
+						}
 
 						switch (statusClass) {
 							case 2:

--- a/packages/appcd-plugin/CHANGELOG.md
+++ b/packages/appcd-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.3.1
+
+ * Fixed plugin IPC tunnel to send the `"headers"` and `"source"` `DispatcherContext` properties.
+   The `"data"` property has been renamed to `"request"` to match the `DispatcherContext` property
+   name. [(DAEMON-273)](https://jira.appcelerator.org/browse/DAEMON-273)
+
 # v1.3.0 (Mar 29, 2019)
 
  * Reimplemented the `/` endpoint using a `DataServiceDispatcher` so that the data can be filtered

--- a/packages/appcd-plugin/src/tunnel.js
+++ b/packages/appcd-plugin/src/tunnel.js
@@ -125,18 +125,15 @@ export default class Tunnel {
 	send(ctxOrPayload) {
 		return new Promise((resolve, reject) => {
 			const id = uuid.v4();
-			let ctx;
+			let ctx = ctxOrPayload;
 
-			if (ctxOrPayload instanceof DispatcherContext) {
-				ctx = ctxOrPayload;
-				ctx.request = {
-					path: ctxOrPayload.path,
-					data: ctxOrPayload.request
-				};
-			} else {
+			if (!(ctxOrPayload instanceof DispatcherContext)) {
 				ctx = new DispatcherContext({
-					request: typeof ctxOrPayload === 'object' && ctxOrPayload || {},
+					headers: {},
+					path:    ctxOrPayload.path,
+					request: typeof ctxOrPayload === 'object' && ctxOrPayload.data || ctxOrPayload || {},
 					response: new PassThrough({ objectMode: true }),
+					source: null,
 					status: 200
 				});
 			}
@@ -216,7 +213,12 @@ export default class Tunnel {
 
 			const req = {
 				id,
-				message: ctx.request,
+				message: {
+					headers: ctx.headers,
+					path:    ctx.path,
+					request: ctx.request,
+					source:  ctx.source
+				},
 				type: 'request'
 			};
 


### PR DESCRIPTION
fix(appcd-plugin): Fixed plugin IPC tunnel to send the 'headers' and 'source' DispatcherContext properties. The 'data' property has been renamed to 'request' to match the DispatcherContext property name. Fixes DAEMON-273.

https://jira.appcelerator.org/browse/DAEMON-273