### PR TITLE
Update telemetry alongside latest specifications

### DIFF
--- a/packages/appcd-core/conf/default.js
+++ b/packages/appcd-core/conf/default.js
@@ -188,7 +188,7 @@ module.exports = {
 		 * GUID to use for telemetry.
 		 * @type {String}
 		 */
-		guid: 'ea327577-858f-4d31-905e-fa670f50ef48',
+		app: 'ea327577-858f-4d31-905e-fa670f50ef48',
 
 		/**
 		 * The maximum number of events to send at a time.

--- a/packages/appcd-core/conf/default.js
+++ b/packages/appcd-core/conf/default.js
@@ -213,6 +213,6 @@ module.exports = {
 		 * The URL to post the telemetry events to.
 		 * @type {String}
 		 */
-		url: 'https://api.appcelerator.com/p/v1/app-track'
+		url: 'https://api.appcelerator.com/p/v4/app-track'
 	}
 };

--- a/packages/appcd-telemetry/src/telemetry.js
+++ b/packages/appcd-telemetry/src/telemetry.js
@@ -42,7 +42,7 @@ export default class Telemetry extends Dispatcher {
 			throw new TypeError('Expected config to be a valid config object');
 		}
 
-		const app = cfg.get('telemetry.app') || cfg.get('telemetry.guid');
+		const app = cfg.get('telemetry.guid') || cfg.get('telemetry.app');
 		if (!app || typeof app !== 'string') {
 			throw new Error('Config is missing a required, valid "telemetry.app"');
 		}

--- a/packages/appcd-telemetry/src/telemetry.js
+++ b/packages/appcd-telemetry/src/telemetry.js
@@ -17,7 +17,7 @@ import uuid from 'uuid';
 
 import { expandPath } from 'appcd-path';
 import { isDir } from 'appcd-fs';
-import { osInfo } from 'appcd-util';
+import { arch, osInfo } from 'appcd-util';
 
 const { __n } = i18n();
 
@@ -119,11 +119,13 @@ export default class Telemetry extends Dispatcher {
 		this.register('/', this.addEvent.bind(this));
 
 		{
+			const architecture = arch();
 			const { name, version } = osInfo();
+
 			this.osInfo = {
 				version,
-				name: 		name || process.platform,
-				arch: 		process.arch
+				name: name || process.platform,
+				arch: architecture
 			};
 		}
 	}
@@ -164,20 +166,20 @@ export default class Telemetry extends Dispatcher {
 				id,
 				data,
 				event,
-				os: 				this.osInfo,
-				app:				this.app,
-				timestamp: 			Date.now(),
-				version: 			'4',
+				os: 		this.osInfo,
+				app:		this.app,
+				timestamp: 	Date.now(),
+				version: 	'4',
 				hardware: {
-					id: 			this.hardwareId
+					id: this.hardwareId
 				},
 				session: {
-					id: 			this.sessionId
+					id: this.sessionId
 				},
 				distribution: {
-					environment: 	this.environment,
-					version: 		this.version
-				},
+					environment:    this.environment,
+					version:        this.version
+				}
 			};
 
 			const filename = path.join(this.eventsDir, `${id}.json`);

--- a/packages/appcd-telemetry/src/telemetry.js
+++ b/packages/appcd-telemetry/src/telemetry.js
@@ -42,7 +42,8 @@ export default class Telemetry extends Dispatcher {
 			throw new TypeError('Expected config to be a valid config object');
 		}
 
-		const app = cfg.get('telemetry.guid') || cfg.get('telemetry.app');
+		// telemetry.guid can be removed in 3.x as telemetry.app is favoured
+		const app = cfg.get('telemetry.app') || cfg.get('telemetry.guid');
 		if (!app || typeof app !== 'string') {
 			throw new Error('Config is missing a required, valid "telemetry.app"');
 		}

--- a/packages/appcd-telemetry/src/telemetry.js
+++ b/packages/appcd-telemetry/src/telemetry.js
@@ -21,7 +21,7 @@ import { arch, osInfo } from 'appcd-util';
 
 const { __n } = i18n();
 
-const { error, log } = appcdLogger('appcd:telemetry');
+const { error, log, warn } = appcdLogger('appcd:telemetry');
 const { highlight } = appcdLogger.styles;
 
 const jsonRegExp = /\.json$/;
@@ -117,6 +117,7 @@ export default class Telemetry extends Dispatcher {
 
 		// wire up the telemetry route
 		this.register('/', this.addEvent.bind(this));
+		this.register('/crash', this.addCrash.bind(this));
 
 		{
 			const architecture = arch();
@@ -201,6 +202,23 @@ export default class Telemetry extends Dispatcher {
 		} catch (e) {
 			ctx.response = e;
 		}
+	}
+
+	/**
+	 * Handles incoming add crash requests..
+	 *
+	 * @param {Object} ctx - A dispatcher request context.
+	 * @access private
+	 */
+	addCrash(ctx) {
+		if (this.environment !== 'production') {
+			return;
+		}
+		if (!ctx.request.message) {
+			return warn('Error messages must be provided in crashes');
+		}
+		ctx.request.event = 'crash.report';
+		return this.addEvent(ctx);
 	}
 
 	/**

--- a/packages/appcd-telemetry/src/telemetry.js
+++ b/packages/appcd-telemetry/src/telemetry.js
@@ -100,12 +100,6 @@ export default class Telemetry extends Dispatcher {
 		this.sendTimer = null;
 
 		/**
-		 * An internal sequence id that is appended to each event filename.
-		 * @type {Number}
-		 */
-		this.seqId = 1;
-
-		/**
 		 * The session id.
 		 * @type {String}
 		 */
@@ -127,9 +121,9 @@ export default class Telemetry extends Dispatcher {
 		{
 			const { name, version } = osInfo();
 			this.osInfo = {
-				os:       name || 'unknown',
-				osver:    version || 'unknown',
-				platform: process.platform
+				version,
+				name: 		name || process.platform,
+				arch: 		process.arch
 			};
 		}
 	}
@@ -166,19 +160,25 @@ export default class Telemetry extends Dispatcher {
 
 			const id = uuid.v4();
 
-			const payload = Object.assign({
-				aguid:       this.aguid,
-				app_version: this.version,
-				data,
-				deploytype:  this.deployType,
-				event,
+			const payload = {
 				id,
-				mid:         this.mid,
-				seq:         this.seqId++,
-				sid:         this.sessionId,
-				ts:          Date.now(),
-				ver:         3
-			}, this.osInfo);
+				data,
+				event,
+				os: 				this.osInfo,
+				app:				this.aguid,
+				timestamp: 			Date.now(),
+				version: 			'4',
+				hardware: {
+					id: 			this.mid
+				},
+				session: {
+					id: 			this.sessionId
+				},
+				distribution: {
+					environment: 	this.deployType,
+					version: 		this.version
+				},
+			};
 
 			const filename = path.join(this.eventsDir, `${id}.json`);
 

--- a/packages/appcd-telemetry/test/test-telemetry.js
+++ b/packages/appcd-telemetry/test/test-telemetry.js
@@ -143,10 +143,10 @@ describe('telemetry', () => {
 				}
 			});
 
-			expect(telemetry.mid).to.be.null;
+			expect(telemetry.hardwareId).to.be.null;
 			await telemetry.init(makeTempDir());
-			expect(telemetry.mid).to.be.a('string');
-			expect(telemetry.mid).to.not.equal('');
+			expect(telemetry.hardwareId).to.be.a('string');
+			expect(telemetry.hardwareId).to.not.equal('');
 			await telemetry.init(); // would throw a TypeError if no homeDir
 		});
 	});

--- a/packages/appcd-telemetry/test/test-telemetry.js
+++ b/packages/appcd-telemetry/test/test-telemetry.js
@@ -57,7 +57,7 @@ describe('telemetry', () => {
 
 			expect(() => {
 				new Telemetry(cfg);
-			}).to.throw(Error, 'Config is missing a required, valid "telemetry.guid"');
+			}).to.throw(Error, 'Config is missing a required, valid "telemetry.app"');
 		});
 	});
 


### PR DESCRIPTION
This PR will update the telemetry formats to the latest specifications, and point to the latest endpoints. The old endpoints and formats are still accepted, but we want to move everything to the new structures to reduce complexity.

It also introduces crash reporting by sending error messages and stack traces in a `crash.report` event (which uses the internal Crash Analytics system). I'm not sure if how I wired this up is the best way for the daemon though, so open to suggestions! 