### PR TITLE
fix: Replaced call to 'formatWithOptions()' with 'format()'

### DIFF
--- a/packages/appcd-plugin/CHANGELOG.md
+++ b/packages/appcd-plugin/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.6.0 (Jun 7, 2019)
+
+ * fix: Replaced call to `formatWithOptions()` with `format()` so that appcd@1.x would not break
+   on Node.js 8.11.2. [(DAEMON-281)](https://jira.appcelerator.org/browse/DAEMON-281)
+
 # 1.5.0 (Jun 6, 2019)
 
  * fix: Fixed support for scoped plugin package names for nested directory schemes.

--- a/packages/appcd-plugin/package.json
+++ b/packages/appcd-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-plugin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Library for loading and executing plugins.",
   "main": "./dist/index",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",

--- a/packages/appcd-plugin/src/tunnel-stream.js
+++ b/packages/appcd-plugin/src/tunnel-stream.js
@@ -25,7 +25,11 @@ export default class TunnelStream extends Writable {
 	 */
 	_write(message, enc, cb) {
 		if (process.connected && typeof message === 'object') {
-			message.args = [ util.formatWithOptions({ colors: true, depth: null }, ...message.args) ];
+			message.args = [
+				util.format(...message.args.map(a => {
+					return typeof a === 'string' ? a : util.inspect(a, { colors: true, depth: null });
+				}))
+			];
 
 			process.send({
 				type: 'log',


### PR DESCRIPTION
fix: Replaced call to 'formatWithOptions()' with 'format()' so that appcd@1.x would not break on Node.js 8.11.2. (DAEMON-281)

https://jira.appcelerator.org/browse/DAEMON-281