### PR TITLE
feat(appcd-core): update runtime node version to 8.16.0

### DIFF
--- a/packages/appcd-core/package.json
+++ b/packages/appcd-core/package.json
@@ -48,6 +48,6 @@
   "bugs": "https://github.com/appcelerator/appc-daemon/issues",
   "repository": "https://github.com/appcelerator/appc-daemon/tree/master/packages/appcd-core",
   "appcd": {
-    "node": "8.11.1"
+    "node": "8.16.0"
   }
 }


### PR DESCRIPTION
Since a number of packages pull this in, it seems safer to bump this to avoid anymore hiccups