### PR TITLE
fix(core): include sid in context from websockets

### DIFF
--- a/packages/appcd-core/src/websocket-session.js
+++ b/packages/appcd-core/src/websocket-session.js
@@ -120,7 +120,8 @@ export default class WebSocketSession extends EventEmitter {
 			request: {
 				data: req.data || {},
 				id:   req.id,
-				type: req.type
+				type: req.type,
+				sid:  req.sid
 			},
 			response: new PassThrough({ objectMode: true }),
 			source: 'websocket'


### PR DESCRIPTION
Sending `unsubscribe` requests from `appcd-client` fails because the `sid` is not added to the request when using websockets.