### PR TITLE
Bug fixes

### DIFF
--- a/packages/appcd-config-service/CHANGELOG.md
+++ b/packages/appcd-config-service/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v2.0.2
 
+ * fix: Fixed bug where `push` and `unshift` actions were not returning the new value.
  * chore: Fixed homepage and repository URLs in `package.json`.
  * chore: Added links to issue trackers in readme.
  * chore: Bumped required Node.js version to 8.12.0 which is technically a breaking change, but

--- a/packages/appcd-config-service/src/config-service.js
+++ b/packages/appcd-config-service/src/config-service.js
@@ -114,6 +114,7 @@ export default class ConfigService extends ServiceDispatcher {
 
 						case 'push':
 							this.config.push(key, data.value);
+							value = this.config.get(key);
 							break;
 
 						case 'pop':
@@ -126,6 +127,7 @@ export default class ConfigService extends ServiceDispatcher {
 
 						case 'unshift':
 							this.config.unshift(key, data.value);
+							value = this.config.get(key);
 							break;
 					}
 				} catch (e) {

--- a/test/test-appcd-config.js
+++ b/test/test-appcd-config.js
@@ -457,7 +457,7 @@ describe('appcd config', function () {
 				});
 			}
 
-			describe.only('arrays', () => {
+			describe('arrays', () => {
 				it('should push to an array config value', makeTest(async function () {
 					await this.initHomeDir(path.join(__dirname, 'fixtures', 'array-config'));
 


### PR DESCRIPTION
fix(config-service): Fixed bug where 'push' and 'unshift' actions were not returning the new value.
test: Removed 'only'.