### PR TITLE
fix: use correct npm prefix

### DIFF
--- a/packages/appcd/package.json
+++ b/packages/appcd/package.json
@@ -38,7 +38,7 @@
     "appcd-util": "^2.0.0",
     "cli-kit": "^0.12.0",
     "cli-table2": "^0.2.0",
-    "global-modules": "^2.0.0",
+    "global-prefix": "^3.0.0",
     "humanize": "^0.0.9",
     "source-map-support": "^0.5.13",
     "v8-compile-cache": "^2.1.0"

--- a/packages/appcd/src/common.js
+++ b/packages/appcd/src/common.js
@@ -1,7 +1,7 @@
 import appcdLogger from 'appcd-logger';
 import Client from 'appcd-client';
 import fs from 'fs';
-import globalModules from 'global-modules';
+import globalPrefix from 'global-prefix';
 import path from 'path';
 
 import { expandPath } from 'appcd-path';
@@ -120,7 +120,7 @@ export async function startServer({ cfg, argv }) {
 		process.env.APPCD_NO_COLORS = 1;
 	}
 	process.env.FORCE_COLOR = 1;
-	process.env.PREFIX = globalModules;
+	process.env.PREFIX = globalPrefix;
 
 	try {
 		const { generateV8MemoryArgument, spawnNode } = await import('appcd-nodejs');


### PR DESCRIPTION
`global-modules` returns the full path to the global `node_modules` folder. Since it is used twice (once in `appcd`, and again in `appcd-core`) this results in a global plugin path like `/Users/jvennemann/.nvm/versions/node/v10.13.0/lib/node_modules/lib/node_modules`. This PR will switch to the underlying `global-prefix` module, which just returns the NPM prefix path.