### PR TITLE
fix(plugin): require API compatibility

### DIFF
--- a/packages/appcd-gulp/CHANGELOG.md
+++ b/packages/appcd-gulp/CHANGELOG.md
@@ -6,6 +6,7 @@
  * feat: Added lcov report output for coverage tests.
  * fix: Fixed `gulp watch` to continue to watch after a lint or build error occurs.
  * fix: Fixed coverage transpilation to factor in if module is the main entry point.
+ * fix: Added missing fourth `options` argument to transpile `Module._resolveFilename()` override.
  * refactor: Moved `runTests()` out of standard template and into a separate `test-runner.js` file.
  * chore: Fixed homepage and repository URLs in `package.json`.
  * chore: Added links to issue trackers in readme.

--- a/packages/appcd-gulp/src/test-transpile.js
+++ b/packages/appcd-gulp/src/test-transpile.js
@@ -68,7 +68,7 @@ if (process.env.APPCD_COVERAGE) {
 	const distGRegExp = /([/\\])dist([/\\]|$)/g;
 	const appcdPkg = /^appcd/;
 
-	Module._resolveFilename = function (request, parent, isMain) {
+	Module._resolveFilename = function (request, parent, isMain, options) {
 		const parentId = parent && path.resolve(parent.id);
 
 		if (distRegExp.test(request) && (isMain || (parentId && (parentId.startsWith(cwd) || parentId.startsWith(realcwd)) && !parentId.includes('node_modules')))) {
@@ -93,6 +93,6 @@ if (process.env.APPCD_COVERAGE) {
 			}
 		}
 
-		return originalResolveFilename(request, parent, isMain);
+		return originalResolveFilename(request, parent, isMain, options);
 	};
 }

--- a/packages/appcd-nodejs/CHANGELOG.md
+++ b/packages/appcd-nodejs/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.0.1
 
+ * fix: Discontinue automatic unref of detached subprocesses.
  * chore: Fixed homepage and repository URLs in `package.json`.
  * chore: Added links to issue trackers in readme.
  * chore: Bumped required Node.js version to 8.12.0 which is technically a breaking change, but

--- a/packages/appcd-nodejs/src/nodejs.js
+++ b/packages/appcd-nodejs/src/nodejs.js
@@ -436,11 +436,7 @@ export async function spawnNode({ arch, args, detached, nodeHome, nodeArgs, stdi
 	return (async function trySpawn() {
 		try {
 			tries--;
-			const child = spawn(node, args, opts);
-			if (detached) {
-				child.unref();
-			}
-			return child;
+			return spawn(node, args, opts);
 		} catch (err) {
 			if ((err.code === 'ETXTBSY' || err.code === 'EBUSY') && tries) {
 				logger.log(`Spawn threw ${err.code}, retrying...`);

--- a/packages/appcd-plugin/CHANGELOG.md
+++ b/packages/appcd-plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
  * feat: Added `dependencies` to plugin info.
  * feat: `console` object is now a Node.js Console object instead of a SnoopLogg logger.
  * fix: Added support for non-transpiled plugin code to be instrumented for code coverage.
+ * fix: Improved Node.js module API compatibility.
  * chore: Fixed homepage and repository URLs in `package.json`.
  * chore: Added links to issue trackers in readme.
  * chore: Updated dependencies

--- a/packages/appcd-plugin/src/plugin-module.js
+++ b/packages/appcd-plugin/src/plugin-module.js
@@ -179,13 +179,8 @@ export default class PluginModule extends Module {
 			});
 
 			const require = request => this.require(request);
-			let resolve = (request, options) => Module._resolveFilename(request, this, false, options);
-			if (semver.lt(process.version, '8.9.0')) {
-				resolve = request => Module._resolveFilename(request, this);
-			} else {
-				resolve.paths = request => Module._resolveLookupPaths(request, this, true);
-			}
-			require.resolve = resolve;
+			require.resolve = (request, options) => Module._resolveFilename(request, this, false, options);
+			require.resolve.paths = request => Module._resolveLookupPaths(request, this, true);
 			require.extensions = Module._extensions;
 			require.cache = Module._cache;
 			require.main = process.mainModule;

--- a/packages/appcd-plugin/src/plugin-module.js
+++ b/packages/appcd-plugin/src/plugin-module.js
@@ -178,10 +178,17 @@ export default class PluginModule extends Module {
 				displayErrors: false
 			});
 
-			const require = path => this.require(path);
-			require.resolve = path => Module._resolveFilename(path, this);
+			const require = request => this.require(request);
+			let resolve = (request, options) => Module._resolveFilename(request, this, false, options);
+			if (semver.lt(process.version, '8.9.0')) {
+				resolve = request => Module._resolveFilename(request, this);
+			} else {
+				resolve.paths = request => Module._resolveLookupPaths(request, this, true);
+			}
+			require.resolve = resolve;
 			require.extensions = Module._extensions;
 			require.cache = Module._cache;
+			require.main = process.mainModule;
 
 			const args = [
 				this.exports,

--- a/packages/appcd-plugin/test/fixtures/require-api.js
+++ b/packages/appcd-plugin/test/fixtures/require-api.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+exports.main = require.main;
+
+exports.resolved = require.resolve('fs-extra');
+exports.resolvedWithOptions = require.resolve('./fixtures/require-api', {
+  paths: [ path.resolve(__dirname, '..') ]
+});
+
+exports.paths = require.resolve.paths('fs-extra');

--- a/packages/appcd-plugin/test/test-plugin-module.js
+++ b/packages/appcd-plugin/test/test-plugin-module.js
@@ -7,34 +7,51 @@ function MockPlugin() {
 }
 
 describe('Plugin Module', () => {
+	let plugin;
+
+	beforeEach(() => {
+		plugin = new MockPlugin();
+	});
+
+	afterEach(() => {
+		plugin = null;
+	});
+
 	it('should load a vanilla js file', () => {
-		const plugin = new MockPlugin();
 		const exports = PluginModule.load(plugin, path.join(__dirname, 'fixtures', 'vanilla.js'));
 		expect(exports).to.deep.equal({ foo: 'bar' });
 	});
 
 	it('should load a js file that requires a vanilla js file', () => {
-		const plugin = new MockPlugin();
 		const exports = PluginModule.load(plugin, path.join(__dirname, 'fixtures', 'req.js'));
 		expect(exports).to.deep.equal({ foo: 'bar' });
 	});
 
 	it('should fail to load if js file requires a non-existent file', () => {
-		const plugin = new MockPlugin();
 		expect(() => {
 			PluginModule.load(plugin, path.join(__dirname, 'fixtures', 'bad-req.js'));
 		}).to.throw(Error, 'Failed to load plugin: Cannot find module \'does_not_exist\'');
 	});
 
 	it('should load js file that requires built-in module', () => {
-		const plugin = new MockPlugin();
 		const exports = PluginModule.load(plugin, path.join(__dirname, 'fixtures', 'req-builtin.js'));
 		expect(exports).to.equal(os.hostname());
 	});
 
 	it('should load js file that requires a 3rd party module', () => {
-		const plugin = new MockPlugin();
 		const exports = PluginModule.load(plugin, path.join(__dirname, 'fixtures', 'req-3rd-party.js'));
 		expect(exports).to.equal(os.hostname());
+	});
+
+	it('should provide Node.js compatible require api', () => {
+		const testModule = path.join(__dirname, 'fixtures', 'require-api.js');
+		const exports = PluginModule.load(plugin, testModule);
+		expect(exports.main).to.equal(process.mainModule);
+		expect(exports.resolved).to.equal(require.resolve('fs-extra'));
+		expect(exports.resolvedWithOptions).to.equal(require.resolve('./fixtures/require-api'));
+		const paths = require.resolve.paths('fs-extra');
+		// manually add fixtures subpath
+		paths.unshift(path.join(path.dirname(testModule), 'node_modules'));
+		expect(exports.paths).to.eql(paths);
 	});
 });

--- a/packages/appcd-response/CHANGELOG.md
+++ b/packages/appcd-response/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v2.0.2
 
+ * fix(locale): Removed dependency on `winreglib` for detecting the locale on Windows in favor of
+   spawning the Windows Registry `reg.exe` command.
+   [(DAEMON-287)](https://jira.appcelerator.org/browse/DAEMON-287)
  * chore: Fixed homepage and repository URLs in `package.json`.
  * chore: Added links to issue trackers in readme.
 

--- a/packages/appcd-response/package.json
+++ b/packages/appcd-response/package.json
@@ -19,8 +19,7 @@
     "appcd-fs": "^1.1.8",
     "appcd-path": "^1.1.7",
     "source-map-support": "^0.5.13",
-    "sprintf-js": "^1.1.2",
-    "winreglib": "^1.0.5"
+    "sprintf-js": "^1.1.2"
   },
   "devDependencies": {
     "appcd-gulp": "^2.2.0"
@@ -29,6 +28,6 @@
   "bugs": "https://github.com/appcelerator/appc-daemon/issues",
   "repository": "https://github.com/appcelerator/appc-daemon/tree/master/packages/appcd-response",
   "engines": {
-    "node": "^8.12.0 || >=10.2.0"
+    "node": ">=8.0.0"
   }
 }

--- a/packages/appcd-response/src/locale.js
+++ b/packages/appcd-response/src/locale.js
@@ -1,4 +1,6 @@
-/* eslint security/detect-child-process: 0 */
+/* eslint security/detect-child-process: 0, security/detect-non-literal-regexp: 0 */
+
+import { spawnSync } from 'child_process';
 
 /**
  * The cached locale value.
@@ -11,30 +13,31 @@ let cachedLocale;
  * Determines the current locale of this machine.
  *
  * @param {Boolean} [force=false] - When `true`, it will bypass the cached locale and redetect.
- * @returns {Promise<String>}
+ * @returns {Promise<String>} Resolves the locale or `null` if a locale cannot be determined.
  */
 export async function locale(force) {
 	if (!force && cachedLocale !== undefined) {
 		return cachedLocale;
 	}
 
+	cachedLocale = null;
+
 	try {
 		if (process.platform === 'win32') {
-			const winreglib = require('winreglib');
-			let value = winreglib.get('HKCU\\Control Panel\\International', 'Locale');
-			if (value) {
-				value = value.substring(value.length - 4, value.length);
-				const locale = winreglib.get('HKLM\\SOFTWARE\\Classes\\MIME\\Database\\Rfc1766', value);
-				const m = locale.match(/([^;,\n]+?);/);
-				cachedLocale = m ? m[1].replace(/_/g, '-') : null;
+			let r = spawnSync('reg', [ 'query', 'HKCU\\Control Panel\\International', '/v', 'Locale' ]);
+			let m = !r.status && r.stdout.toString().trim().match(/Locale\s+\w+\s+(\d+)/);
+			if (m) {
+				const code = m[1].substr(-4);
+				r = spawnSync('reg', [ 'query', 'HKLM\\SOFTWARE\\Classes\\MIME\\Database\\Rfc1766', '/v', code ]);
+				m = !r.status && r.stdout.toString().trim().match(new RegExp(`${code}\\s+\\w+\\s+([^;,\n]+)`));
+				cachedLocale = m ? m[1] : null;
 			}
 		} else {
-			const m = require('child_process').spawnSync('locale').stdout.toString().match(/^LANG="?([^".\s]+)/);
+			const m = spawnSync('locale').stdout.toString().match(/^LANG="?([^".\s]+)/);
 			cachedLocale = m ? m[1].replace(/_/g, '-') : null;
 		}
 	} catch (e) {
 		// this can happen if the 'locale' command is not found in the system path
-		cachedLocale = null;
 	}
 
 	return cachedLocale;

--- a/packages/appcd/CHANGELOG.md
+++ b/packages/appcd/CHANGELOG.md
@@ -5,6 +5,8 @@
  * fix(common): Fixed bug where the incorrect global package directory was being resolved based on
    the Node.js executable used to spawn the core instead of the Node.js version used to run the
    `appcd` command.
+ * fix(common): Re-enable detaching the core when starting the daemon to prevent unintended SIGINT
+   propagation. [(DAEMON-288)](https://jira.appcelerator.org/browse/DAEMON-288)
  * fix(config): Fixed config 'delete' aliases when daemon is not running.
  * chore: Fixed homepage and repository URLs in `package.json`.
  * chore: Added links to issue trackers in readme.

--- a/packages/appcd/src/common.js
+++ b/packages/appcd/src/common.js
@@ -134,14 +134,7 @@ export async function startServer({ cfg, argv }) {
 
 			child = await spawnNode({
 				args,
-
-				// On macOS (and probably Linux), a detached process doesn't stick around to see
-				// if the executable exited with an error, so we must not detach the process,
-				// but rather disconnect it once the daemon is booted. On Windows, we have to
-				// detach it to keep the process running and for some lucky reason, Node sticks
-				// around to see if the executable errors.
-				detached: process.platform === 'win32' ? detached : false,
-
+				detached,
 				nodeHome: expandPath(cfg.get('home'), 'node'),
 				stdio,
 				v8mem,


### PR DESCRIPTION
Fix `require` compatibility in plugin modules.

- Add `require.resolve.paths`
- Add `require.main`