### PR TITLE
fix: Detached core process [DAEMON-288]

### DIFF
--- a/packages/appcd-nodejs/CHANGELOG.md
+++ b/packages/appcd-nodejs/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.0.1
 
+ * fix: Discontinue automatic unref of detached subprocesses.
  * chore: Fixed homepage and repository URLs in `package.json`.
  * chore: Added links to issue trackers in readme.
  * chore: Bumped required Node.js version to 8.12.0 which is technically a breaking change, but

--- a/packages/appcd-nodejs/src/nodejs.js
+++ b/packages/appcd-nodejs/src/nodejs.js
@@ -436,11 +436,7 @@ export async function spawnNode({ arch, args, detached, nodeHome, nodeArgs, stdi
 	return (async function trySpawn() {
 		try {
 			tries--;
-			const child = spawn(node, args, opts);
-			if (detached) {
-				child.unref();
-			}
-			return child;
+			return spawn(node, args, opts);
 		} catch (err) {
 			if ((err.code === 'ETXTBSY' || err.code === 'EBUSY') && tries) {
 				logger.log(`Spawn threw ${err.code}, retrying...`);

--- a/packages/appcd/CHANGELOG.md
+++ b/packages/appcd/CHANGELOG.md
@@ -5,6 +5,8 @@
  * fix(common): Fixed bug where the incorrect global package directory was being resolved based on
    the Node.js executable used to spawn the core instead of the Node.js version used to run the
    `appcd` command.
+ * fix(common): Re-enable detaching the core when starting the daemon to prevent unintended SIGINT
+   propagation. [(DAEMON-288)](https://jira.appcelerator.org/browse/DAEMON-288)
  * fix(config): Fixed config 'delete' aliases when daemon is not running.
  * chore: Fixed homepage and repository URLs in `package.json`.
  * chore: Added links to issue trackers in readme.

--- a/packages/appcd/src/common.js
+++ b/packages/appcd/src/common.js
@@ -134,14 +134,7 @@ export async function startServer({ cfg, argv }) {
 
 			child = await spawnNode({
 				args,
-
-				// On macOS (and probably Linux), a detached process doesn't stick around to see
-				// if the executable exited with an error, so we must not detach the process,
-				// but rather disconnect it once the daemon is booted. On Windows, we have to
-				// detach it to keep the process running and for some lucky reason, Node sticks
-				// around to see if the executable errors.
-				detached: process.platform === 'win32' ? detached : false,
-
+				detached,
 				nodeHome: expandPath(cfg.get('home'), 'node'),
 				stdio,
 				v8mem,


### PR DESCRIPTION
fix(appcd): Re-enable detaching the core when starting the daemon to prevent unintended SIGINT propagation. [DAEMON-288]
fix(appcd-nodejs): Discontinue automatic unref of detached subprocesses.

https://jira.appcelerator.org/browse/DAEMON-288