### PR TITLE
Yarn not found during plugin install at startup

### DIFF
--- a/packages/appcd-default-plugins/CHANGELOG.md
+++ b/packages/appcd-default-plugins/CHANGELOG.md
@@ -1,5 +1,7 @@
-# v4.2.1
+# v4.2.1 (Mar 3, 2020)
 
+ * fix: Explicitly update PATH environment variable so that it is properly inherited by the child
+   process on Windows. [(DAEMON-330)](https://jira.appcelerator.org/browse/DAEMON-330)
  * chore: Updated dependencies.
 
 # v4.2.0 (Jan 13, 2020)

--- a/packages/appcd-default-plugins/package.json
+++ b/packages/appcd-default-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-default-plugins",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A psuedo package that bundles all default appcd plugins.",
   "main": "./dist/index",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",


### PR DESCRIPTION
For some reason, on Windows, an overwritten PATH in the environment variables is not properly inherited when calling spawn(), however if we override the environment variables for the current process, they are properly inherited. This could be just a Node 10 issue.

JIRA: https://jira.appcelerator.org/browse/DAEMON-330