### PR TITLE
feat: allow disabling appcd postinstall script

### DIFF
--- a/docs/Environment Variables.md
+++ b/docs/Environment Variables.md
@@ -12,7 +12,7 @@
 | APPCD_LOCALE              | The preferred locale to use such as `en_US`. Defaults to the system's value. |
 | APPCD_SERVER_PORT         | The port that the appc daemon should listen on. Defaults to `1732`. The port number must be between `1024` and `65535`. |
 | APPCD_TELEMETRY           | Controls the telemetry system. Set to `0` or `false` to disable telemetry. Defaults to `true`. |
-| APPCD_SKIP_POSTINSTALL    | Disable the postinstall script of the main appcd package |
+| APPCD_SKIP_POSTINSTALL    | Disable the postinstall script of the main appcd package. |
 
 ## Private Environment Variables
 

--- a/docs/Environment Variables.md
+++ b/docs/Environment Variables.md
@@ -12,6 +12,7 @@
 | APPCD_LOCALE              | The preferred locale to use such as `en_US`. Defaults to the system's value. |
 | APPCD_SERVER_PORT         | The port that the appc daemon should listen on. Defaults to `1732`. The port number must be between `1024` and `65535`. |
 | APPCD_TELEMETRY           | Controls the telemetry system. Set to `0` or `false` to disable telemetry. Defaults to `true`. |
+| APPCD_SKIP_POSTINSTALL    | Disable the postinstall script of the main appcd package |
 
 ## Private Environment Variables
 

--- a/packages/appcd/scripts/postinstall.js
+++ b/packages/appcd/scripts/postinstall.js
@@ -13,6 +13,10 @@
  * If the user is noobody, display the manual install message.
  */
 
+if (process.env.APPCD_SKIP_POSTINSTALL) {
+	return;
+}
+
 const { expandPath } = require('appcd-path');
 const { snooplogg } = require('appcd-logger');
 const { cyan, yellow } = snooplogg.chalk;


### PR DESCRIPTION
Allowing set a `APPCD_SKIP_POSTINSTALL` environment variable to stop the postinstall script in appcd being ran, this will be used by the appc cli when performing an npm rebuild when switching node versions