### PR TITLE
[DAEMON-342] Fix circular ref removal

### DIFF
--- a/packages/appcd-util/CHANGELOG.md
+++ b/packages/appcd-util/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.1.6
+
+ * fix(makeSerializable): Only ignore nested duplicates that form circular references instead of
+   anything that is a duplicate. [(DAEMON-342)](https://jira.appcelerator.org/browse/DAEMON-342)
+
 # v3.1.5 (Apr 15, 2021)
 
  * fix(redact): Use `os.homedir()` instead of `process.env.HOME` to get users home directory.

--- a/packages/appcd-util/test/test-util.js
+++ b/packages/appcd-util/test/test-util.js
@@ -490,7 +490,7 @@ describe('util', () => {
 		});
 	});
 
-	describe('makeSerializable()', () => {
+	describe.only('makeSerializable()', () => {
 		it('should pass through non-objects', () => {
 			expect(util.makeSerializable()).to.equal(undefined);
 			expect(util.makeSerializable(undefined)).to.equal(undefined);
@@ -524,6 +524,17 @@ describe('util', () => {
 			expect(util.makeSerializable(obj)).to.deep.equal({
 				a: undefined,
 				b: [ undefined ]
+			});
+		});
+
+		it('should not remove non-ciruclar references', () => {
+			const obj = {};
+			const meta = { msg: 'hi' };
+			obj.a = meta;
+			obj.b = meta;
+			expect(util.makeSerializable(obj)).to.deep.equal({
+				a: { msg: 'hi' },
+				b: { msg: 'hi' }
 			});
 		});
 	});

--- a/packages/appcd-util/test/test-util.js
+++ b/packages/appcd-util/test/test-util.js
@@ -490,7 +490,7 @@ describe('util', () => {
 		});
 	});
 
-	describe.only('makeSerializable()', () => {
+	describe('makeSerializable()', () => {
 		it('should pass through non-objects', () => {
 			expect(util.makeSerializable()).to.equal(undefined);
 			expect(util.makeSerializable(undefined)).to.equal(undefined);
@@ -524,6 +524,14 @@ describe('util', () => {
 			expect(util.makeSerializable(obj)).to.deep.equal({
 				a: undefined,
 				b: [ undefined ]
+			});
+
+			const a = { foo: 'bar' };
+			const b = { baz: 'wiz', a };
+			a.b = b;
+			expect(util.makeSerializable({ a, b })).to.deep.equal({
+				a: { foo: 'bar', b: { baz: 'wiz', a: undefined } },
+				b: { baz: 'wiz', a: { foo: 'bar', b: undefined } }
 			});
 		});
 


### PR DESCRIPTION
fix(util:makeSerializable): Only ignore nested duplicates that form circular references instead of anything that is a duplicate.

JIRA: https://jira.appcelerator.org/browse/DAEMON-342