### PR TITLE
appcd-gulp test coverage improvements

### DIFF
--- a/packages/appcd-gulp/CHANGELOG.md
+++ b/packages/appcd-gulp/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.2.0
+
+ * feat(test): Exposed Mocha `slow` and `timeout` parameters in test runner.
+ * fix(coverage): Simplified coverage file resolution by letting Node's module system find the
+   module first, then switch the resolved filename from the `dist` version to the `src` version if
+   the file is apart of the package being tested.
+
 # v3.1.6 (Apr 26, 2021)
 
  * chore: Updated dependencies.

--- a/packages/appcd-gulp/src/test-runner.js
+++ b/packages/appcd-gulp/src/test-runner.js
@@ -6,7 +6,7 @@ const { spawnSync } = require('child_process');
 
 const isWindows   = process.platform === 'win32';
 
-exports.runTests = async function runTests({ root, projectDir, cover, all }) {
+exports.runTests = async function runTests({ all, cover, projectDir, root, slow, timeout }) {
 	const args = [];
 	let { execPath } = process;
 
@@ -56,6 +56,11 @@ exports.runTests = async function runTests({ root, projectDir, cover, all }) {
 	// add --inspect
 	if (process.argv.includes('--debug') || process.argv.includes('--inspect') || process.argv.includes('--inspect-brk')) {
 		args.push('--inspect-brk', '--timeout', '9999999');
+	} else if (timeout) {
+		args.push('--timeout', timeout);
+	}
+	if (slow) {
+		args.push('--slow', slow);
 	}
 
 	const jenkinsReporter = resolveModule(root, 'mocha-jenkins-reporter');


### PR DESCRIPTION
* feat(test): Exposed Mocha 'slow' and 'timeout' parameters in test runner.
* fix(coverage): Simplified coverage file resolution by letting Node's module system find the module first, then switch the resolved filename from the 'dist' version to the 'src' version if the file is apart of the package being tested.