### PR TITLE
appcd-fs@2.1.0

### DIFF
--- a/packages/appcd-fs/CHANGELOG.md
+++ b/packages/appcd-fs/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.1.0 (Jun 8, 2021)
+
+ * feat: Added `mkdirpSync()`, `moveSync()`, and `writeFileSync()` helpers that create parent
+   directories and apply parent directory ownership.
+ * chore: Updated dependencies.
+
 # v2.0.7 (Apr 26, 2021)
 
  * chore: Updated dependencies.

--- a/packages/appcd-fs/package.json
+++ b/packages/appcd-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcd-fs",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Library of useful filesystem functions.",
   "main": "./dist/fs",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",
@@ -16,10 +16,11 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "source-map-support": "^0.5.19"
+    "source-map-support": "^0.5.19",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "appcd-gulp": "^3.1.6"
+    "appcd-gulp": "^3.2.0"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon",
   "bugs": "https://github.com/appcelerator/appc-daemon/issues",

--- a/packages/appcd-fs/src/fs.js
+++ b/packages/appcd-fs/src/fs.js
@@ -7,6 +7,56 @@ import fs from 'fs';
 import path from 'path';
 
 /**
+ * Determines owner of existing parent directory, calls the operation's function, then applies the
+ * owner to the destination and its newly created parent directories.
+ *
+ * @param {String} dest - The destination of the file or directory the operation is targetting.
+ * @param {Object} opts - Various options.
+ * @param {Boolean} [opts.applyOwner=true] - When `true`, determines the owner of the closest
+ * existing parent directory and apply the owner to the file and any newly created directories.
+ * @param {Number} [opts.gid] - The group id to apply to the file when assigning an owner.
+ * @param {Number} [opts.uid] - The user id to apply to the file when assigning an owner.
+ * @param {Function} fn - A function to call to perform the original filesystem operation.
+ */
+function execute(dest, opts, fn) {
+	if (opts.applyOwner === false || process.platform === 'win32' || !process.getuid || process.getuid() !== 0) {
+		fn(opts);
+		return;
+	}
+
+	dest = path.resolve(dest);
+	let origin = path.parse(dest).root;
+
+	if (!opts.uid) {
+		for (origin = dest; true; origin = path.dirname(origin)) {
+			try {
+				const st = fs.lstatSync(origin);
+				if (st.isDirectory()) {
+					opts = Object.assign({}, opts, { gid: st.gid, uid: st.uid });
+					break;
+				}
+			} catch (err) {
+				// continue
+			}
+		}
+	}
+
+	fn(opts);
+
+	const chownSync = fs.lchownSync || fs.chownSync;
+	let stat = fs.lstatSync(dest);
+	while (dest !== origin && stat.uid !== opts.uid) {
+		try {
+			chownSync(dest, opts.uid, opts.gid);
+			dest = path.dirname(dest);
+			stat = fs.lstatSync(dest);
+		} catch (e) {
+			break;
+		}
+	}
+}
+
+/**
  * Determines if a file or directory exists.
  *
  * @param {String} file - The full path to check if exists.
@@ -88,6 +138,41 @@ export function locate(dir, filename, depth) {
 }
 
 /**
+ * Creates a directory and any parent directories if needed.
+ *
+ * @param {String} dest - The directory path to create.
+ * @param {Object} [opts] - Various options plus options to pass into `fs.mkdirSync()`.
+ * @param {Boolean} [opts.applyOwner=true] - When `true`, determines the owner of the closest
+ * existing parent directory and apply the owner to the file and any newly created directories.
+ * @param {Number} [opts.gid] - The group id to apply to the file when assigning an owner.
+ * @param {Number} [opts.uid] - The user id to apply to the file when assigning an owner.
+ */
+export function mkdirpSync(dest, opts = {}) {
+	execute(dest, opts, opts => {
+		fs.mkdirSync(dest, { ...opts, recursive: true });
+	});
+}
+
+/**
+ * Moves a file.
+ *
+ * @param {String} src - The file or directory to move.
+ * @param {String} dest - The destination to move the file or directory to.
+ * @param {Object} [opts] - Various options plus options to pass into `fs.mkdirSync()` and
+ * `fs.renameSync()`.
+ * @param {Boolean} [opts.applyOwner=true] - When `true`, determines the owner of the closest
+ * existing parent directory and apply the owner to the file and any newly created directories.
+ * @param {Number} [opts.gid] - The group id to apply to the file when assigning an owner.
+ * @param {Number} [opts.uid] - The user id to apply to the file when assigning an owner.
+ */
+export function moveSync(src, dest, opts = {}) {
+	execute(dest, opts, opts => {
+		mkdirpSync(path.dirname(dest), opts);
+		fs.renameSync(src, dest, opts);
+	});
+}
+
+/**
  * Read a directory including scoped packages as a single entry in the Array
  * and filtering out all files.
  *
@@ -114,4 +199,23 @@ export function readdirScopedSync(dir) {
 	}
 
 	return children;
+}
+
+/**
+ * Writes a file to disk.
+ *
+ * @param {String} dest - The name of the file to write.
+ * @param {String} contents - The contents of the file to write.
+ * @param {Object} [opts] - Various options plus options to pass into `fs.mkdirSync()` and
+ * `fs.writeFileSync()`.
+ * @param {Boolean} [opts.applyOwner=true] - When `true`, determines the owner of the closest
+ * existing parent directory and apply the owner to the file and any newly created directories.
+ * @param {Number} [opts.gid] - The group id to apply to the file when assigning an owner.
+ * @param {Number} [opts.uid] - The user id to apply to the file when assigning an owner.
+ */
+export function writeFileSync(dest, contents, opts = {}) {
+	execute(dest, opts, opts => {
+		mkdirpSync(path.dirname(dest), opts);
+		fs.writeFileSync(dest, contents, opts);
+	});
 }


### PR DESCRIPTION
* feat(appcd-fs): Added 'mkdirpSync()', 'moveSync()', and 'writeFileSync()' helpers that create parent directories and apply parent directory ownership.
* chore(appcd-fs): Updated dependencies.